### PR TITLE
Release 0.0.3

### DIFF
--- a/custom_updater.json
+++ b/custom_updater.json
@@ -1,0 +1,9 @@
+{
+  "power-wheel-card": {
+    "updated_at": "2018-12-10",
+    "version": "0.0.3",
+    "remote_location": "https://raw.githubusercontent.com/gurbyz/custom-cards-lovelace/master/power-wheel-card/power-wheel-card.js",
+    "visit_repo": "https://github.com/gurbyz/custom-cards-lovelace/tree/master/power-wheel-card",
+    "changelog": "https://github.com/gurbyz/custom-cards-lovelace/blob/master/power-wheel-card/CHANGELOG.md"
+  }
+}

--- a/custom_updater.json
+++ b/custom_updater.json
@@ -1,6 +1,6 @@
 {
   "power-wheel-card": {
-    "updated_at": "2018-12-10",
+    "updated_at": "2018-12-12",
     "version": "0.0.3",
     "remote_location": "https://raw.githubusercontent.com/gurbyz/custom-cards-lovelace/master/power-wheel-card/power-wheel-card.js",
     "visit_repo": "https://github.com/gurbyz/custom-cards-lovelace/tree/master/power-wheel-card",

--- a/custom_updater.json
+++ b/custom_updater.json
@@ -1,6 +1,6 @@
 {
   "power-wheel-card": {
-    "updated_at": "2018-12-12",
+    "updated_at": "2018-12-13",
     "version": "0.0.3",
     "remote_location": "https://raw.githubusercontent.com/gurbyz/custom-cards-lovelace/master/power-wheel-card/power-wheel-card.js",
     "visit_repo": "https://github.com/gurbyz/custom-cards-lovelace/tree/master/power-wheel-card",

--- a/power-wheel-card/CHANGELOG.md
+++ b/power-wheel-card/CHANGELOG.md
@@ -3,13 +3,14 @@ Changelog
 
 ## 0.0.3
 ### New features
-* Added `color_power_icons` as optional boolean card parameter to color the power icons or not (=default).
+* Added `color_power_icons` as optional boolean card parameter to color the power icons or not (=default). Yellow for consuming, green for producing.
 With the new optional card parameters `consuming_color` and `producing_color` you can choose your own colors.
-* Click to open more-info modals.
+* Click on the power icons to open the more-info modals of your sensors.
 * Support for [custom_updater](https://github.com/custom-components/custom_updater) custom component.
 ### Improvements
 * Performance. Moved some code to run it only after config changes.
 * Better syntax for 'Example requirements configuration' in readme.
+* Icon for home power can also be set via `customize:` sensor settings now.
 
 ## 0.0.2
 ### New features

--- a/power-wheel-card/CHANGELOG.md
+++ b/power-wheel-card/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ====
 
+## 0.0.3
+### Improvements
+* Performance. Moved some code to run it only after config changes.
+
 ## 0.0.2
 ### New features
 * Added `solar_power_icon` and `grid_power_icon` as optional card parameters.

--- a/power-wheel-card/CHANGELOG.md
+++ b/power-wheel-card/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog
 ====
 
 ## 0.0.3
+### New features
+* Click to open more-info modals.
 ### Improvements
 * Performance. Moved some code to run it only after config changes.
 

--- a/power-wheel-card/CHANGELOG.md
+++ b/power-wheel-card/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 ## 0.0.3
 ### New features
 * Click to open more-info modals.
+* Support for [custom_updater](https://github.com/custom-components/custom_updater) custom component.
 ### Improvements
 * Performance. Moved some code to run it only after config changes.
 

--- a/power-wheel-card/CHANGELOG.md
+++ b/power-wheel-card/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 ## 0.0.3
 ### New features
+* Added `color_power_icons` as optional boolean card parameter to color the power icons or not (=default).
+With the new optional card parameters `consuming_color` and `producing_color` you can choose your own colors.
 * Click to open more-info modals.
 * Support for [custom_updater](https://github.com/custom-components/custom_updater) custom component.
 ### Improvements

--- a/power-wheel-card/CHANGELOG.md
+++ b/power-wheel-card/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 * Support for [custom_updater](https://github.com/custom-components/custom_updater) custom component.
 ### Improvements
 * Performance. Moved some code to run it only after config changes.
+* Better syntax for 'Example requirements configuration' in readme.
 
 ## 0.0.2
 ### New features

--- a/power-wheel-card/README.md
+++ b/power-wheel-card/README.md
@@ -12,9 +12,10 @@ Features of the custom power-wheel-card:
 * Displays the transition between these powers as arrows.
   E.g. if your solar power panels produce power, the arrow from solar to home turns active.
   And if your solar power panels produce enough power to deliver some back to the grid, the arrow from solar to grid turns active.
+* Optionally uses icons of your own choice, which can be set by card parameters or taken from your `customize:` sensor settings.
 * Optionally colors the consuming power icons yellow and the producing power icons green. You can choose your own colors for consuming and producing.
 * Works for default theme and custom themes that use [standard CSS vars](https://github.com/home-assistant/home-assistant-polymer/blob/master/src/resources/ha-style.js).
-* Support for [custom_updater](https://github.com/custom-components/custom_updater) custom component.
+* Has support for [custom_updater](https://github.com/custom-components/custom_updater) custom component to check for new release via the custom tracker-card.
 
 ![example1](./example-card.gif "The power-wheel-card in Default theme")
 ![example2](./example-card-dark.gif "The power-wheel-card in a random dark theme")
@@ -96,13 +97,13 @@ views:
 |type|string|**required**||Type of the card. Use `"custom:power-wheel-card"`.|
 |title|string|optional|`"Power wheel"`|Title of the card.|
 |solar_power_entity|string|**required**||Entity id of your solar power sensor. E.g. `sensor.YOUR_SOLAR_POWER_SENSOR`. See requirements above.|
-|solar_power_icon|string|optional|The icon of your solar power sensor. If not available, then `"mdi:weather-sunny"` will be used.|Icon for solar power.|
+|solar_power_icon|string|optional|The icon of your own customized solar power sensor. If not available, then `"mdi:weather-sunny"` will be used.|Icon for solar power.|
 |grid_power_entity|string|**required**||Entity id of your grid power sensor. E.g. `sensor.YOUR_GRID_POWER_SENSOR`. See requirements above.|
-|grid_power_icon|string|optional|The icon of your grid power sensor. If not available, then `"mdi:flash-circle"` will be used.|Icon for grid power.|
+|grid_power_icon|string|optional|The icon of your own customized grid power sensor. If not available, then `"mdi:flash-circle"` will be used.|Icon for grid power.|
 |home_power_entity|string|optional|Default the home power value will be calculated.|Entity id of your home power sensor.|
-|home_power_icon|string|optional|`"mdi:home"`|Icon for home power.|
-|decimals|int|optional|`0`|Number of decimals for the power values.|
-|color_power_icons|boolean|optional|`false`|To color the consuming power icons green and the producing color icons yellow.|
+|home_power_icon|string|optional|The icon of your own customized home power sensor if `home_power_entity` is set. If not available, then `"mdi:home"` will be used.|Icon for home power.|
+|decimals|integer|optional|`0`|Number of decimals for the power values.|
+|color_power_icons|boolean|optional|`false`|To color the consuming power icons green and the producing power icons yellow.|
 |consuming_color|string|optional|The yellow color for `--label-badge-yellow` from your theme. If not available, then `"#f4b400"` will be used.|CSS color code for consuming power icons if `color_power_icons` is set to `true`. Examples: `"orange"`, `"#ffcc66"` or `"rgb(200,100,50)"`. Don't forget the quotation marks when using the `#` color notation.|
 |producing_color|string|optional|The green color for `--label-badge-green` from your theme. If not available, then `"#0da035"` will be used.|CSS color code for producing power icons if `color_power_icons` is set to `true`.|
 

--- a/power-wheel-card/README.md
+++ b/power-wheel-card/README.md
@@ -12,6 +12,7 @@ Features of the custom power-wheel-card:
 * Displays the transition between these powers as arrows.
   E.g. if your solar power panels produce power, the arrow from solar to home turns active.
   And if your solar power panels produce enough power to deliver some back to the grid, the arrow from solar to grid turns active.
+* Optionally colors the consuming power icons yellow and the producing power icons green. You can choose your own colors for consuming and producing.
 * Works for default theme and custom themes that use [standard CSS vars](https://github.com/home-assistant/home-assistant-polymer/blob/master/src/resources/ha-style.js).
 * Support for [custom_updater](https://github.com/custom-components/custom_updater) custom component.
 
@@ -85,6 +86,7 @@ views:
       - type: "custom:power-wheel-card"
         solar_power_entity: sensor.YOUR_SOLAR_POWER_SENSOR
         grid_power_entity: sensor.YOUR_GRID_POWER_SENSOR
+        color_power_icons: true
 ```
 
 ## Parameters
@@ -100,6 +102,9 @@ views:
 |home_power_entity|string|optional|Default the home power value will be calculated.|Entity id of your home power sensor.|
 |home_power_icon|string|optional|`"mdi:home"`|Icon for home power.|
 |decimals|int|optional|`0`|Number of decimals for the power values.|
+|color_power_icons|boolean|optional|`false`|To color the consuming power icons green and the producing color icons yellow.|
+|consuming_color|string|optional|The yellow color for `--label-badge-yellow` from your theme. If not available, then `"#f4b400"` will be used.|CSS color code for consuming power icons if `color_power_icons` is set to `true`. Examples: `"orange"`, `"#ffcc66"` or `"rgb(200,100,50)"`. Don't forget the quotation marks when using the `#` color notation.|
+|producing_color|string|optional|The green color for `--label-badge-green` from your theme. If not available, then `"#0da035"` will be used.|CSS color code for producing power icons if `color_power_icons` is set to `true`.|
 
 ### More about icons
 The icons for solar power and grid power can be set by card parameters as shown in the table above.
@@ -129,6 +134,9 @@ A more advanced example for in the `ui-lovelace.yaml` file:
   grid_power_icon: "mdi:flash"
   home_power_icon: "mdi:home-assistant"
   decimals: 2
+  color_power_icons: true
+  consuming_color: "#33ff33"
+  producing_color: "#dd5500"
 ```
 
 ## License

--- a/power-wheel-card/README.md
+++ b/power-wheel-card/README.md
@@ -13,6 +13,7 @@ Features of the custom power-wheel-card:
   E.g. if your solar power panels produce power, the arrow from solar to home turns active.
   And if your solar power panels produce enough power to deliver some back to the grid, the arrow from solar to grid turns active.
 * Works for default theme and custom themes that use [standard CSS vars](https://github.com/home-assistant/home-assistant-polymer/blob/master/src/resources/ha-style.js).
+* Support for [custom_updater](https://github.com/custom-components/custom_updater) custom component.
 
 ![example1](./example-card.gif "The power-wheel-card in Default theme")
 ![example2](./example-card-dark.gif "The power-wheel-card in a random dark theme")

--- a/power-wheel-card/README.md
+++ b/power-wheel-card/README.md
@@ -44,11 +44,14 @@ sensor:
       solar_power:
         friendly_name: 'Solar power production'
         unit_of_measurement: 'W'
-        value_template: '{{ states.sensor.youless.attributes.pwr }}'
+        value_template: >-
+          {{ state_attr("sensor.youless", "pwr") }}
       grid_power:
         friendly_name: 'Grid power consumption'
         unit_of_measurement: 'W'
-        value_template: '{{ (1000 * (states.sensor.power_consumption.state | float - states.sensor.power_production.state | float)) | int }}'
+        value_template: >-
+          {{ (1000 * (states("sensor.power_consumption") | float -
+                      states("sensor.power_production") | float)) | int }}
 ```
 
 In this example the sensors names for *YOUR_SOLAR_POWER_SENSOR* and *YOUR_GRID_POWER_SENSOR* are `solar_power` resp. `grid_power`.

--- a/power-wheel-card/power-wheel-card.js
+++ b/power-wheel-card/power-wheel-card.js
@@ -11,26 +11,23 @@ class PowerWheelCard extends LitElement {
   }
 
   _render({ hass, config }) {
-    const title = config.title ? config.title : 'Power wheel';
-    const decimals = config.decimals ? config.decimals : 0;
-
     const solarPowerState = hass.states[config.solar_power_entity];
-    const solarPowerStateStr = solarPowerState ? parseFloat(solarPowerState.state).toFixed(decimals) : 'unavailable';
+    const solarPowerStateStr = solarPowerState ? parseFloat(solarPowerState.state).toFixed(this.decimals) : 'unavailable';
     const solarPowerIcon = config.solar_power_icon ? config.solar_power_icon
       : (solarPowerState && solarPowerState.attributes.icon ? solarPowerState.attributes.icon : 'mdi:weather-sunny');
 
     const gridPowerState = hass.states[config.grid_power_entity];
-    const gridPowerStateStr = gridPowerState ? parseFloat(gridPowerState.state).toFixed(decimals) : 'unavailable';
+    const gridPowerStateStr = gridPowerState ? parseFloat(gridPowerState.state).toFixed(this.decimals) : 'unavailable';
     const gridPowerIcon = config.grid_power_icon ? config.grid_power_icon
       : (gridPowerState && gridPowerState.attributes.icon ? gridPowerState.attributes.icon : 'mdi:flash-circle');
 
     let homePowerStateStr;
     if (config.home_power_entity) { // home power value by sensor
       const homePowerState = hass.states[config.home_power_entity];
-      homePowerStateStr = homePowerState ? parseFloat(homePowerState.state).toFixed(decimals) : 'unavailable';
+      homePowerStateStr = homePowerState ? parseFloat(homePowerState.state).toFixed(this.decimals) : 'unavailable';
     } else { // home power value by calculation
       homePowerStateStr = solarPowerState && gridPowerState
-        ? (parseFloat(solarPowerState.state) + parseFloat(gridPowerState.state)).toFixed(decimals) : 'unavailable';
+        ? (parseFloat(solarPowerState.state) + parseFloat(gridPowerState.state)).toFixed(this.decimals) : 'unavailable';
     }
     const homePowerIcon = config.home_power_icon ? config.home_power_icon : 'mdi:home';
 
@@ -88,7 +85,7 @@ class PowerWheelCard extends LitElement {
       </style>
       <ha-card>
         <div class="header">
-          ${title}
+          ${this.title}
         </div>
         <div class="row">
           <div class="cell">
@@ -128,9 +125,11 @@ class PowerWheelCard extends LitElement {
     if (!config.grid_power_entity) {
       throw new Error('You need to define a grid_power_entity');
     }
+    this.title = config.title ? config.title : 'Power wheel';
     if (config.decimals && !Number.isInteger(config.decimals)) {
       throw new Error('Decimals should be an integer');
     }
+    this.decimals = config.decimals ? config.decimals : 0;
     this.config = config;
   }
 

--- a/power-wheel-card/power-wheel-card.js
+++ b/power-wheel-card/power-wheel-card.js
@@ -26,11 +26,14 @@ class PowerWheelCard extends LitElement {
 
     let homePowerState,
         homePowerStateStr,
-        homePowerClass;
+        homePowerClass,
+        homePowerIcon;
     if (config.home_power_entity) { // home power value by sensor
       homePowerState = hass.states[config.home_power_entity];
       homePowerStateStr = homePowerState ? parseFloat(homePowerState.state).toFixed(this.decimals) : 'unavailable';
       homePowerClass = (homePowerState && parseFloat(homePowerState.state) > 0) ? 'consuming' : 'inactive';
+      homePowerIcon = config.home_power_icon ? config.home_power_icon
+        : (homePowerState && homePowerState.attributes.icon ? homePowerState.attributes.icon : 'mdi:home');
     } else { // home power value by calculation
       if (solarPowerState && gridPowerState) {
         homePowerStateStr = (parseFloat(solarPowerState.state) + parseFloat(gridPowerState.state)).toFixed(this.decimals);
@@ -39,8 +42,8 @@ class PowerWheelCard extends LitElement {
         homePowerStateStr = 'unavailable';
         homePowerClass = 'inactive';
       }
+      homePowerIcon = config.home_power_icon ? config.home_power_icon : 'mdi:home';
     }
-    const homePowerIcon = config.home_power_icon ? config.home_power_icon : 'mdi:home';
 
     const unitStr = solarPowerState && gridPowerState
       && solarPowerState.attributes.unit_of_measurement && gridPowerState.attributes.unit_of_measurement

--- a/power-wheel-card/power-wheel-card.js
+++ b/power-wheel-card/power-wheel-card.js
@@ -21,9 +21,10 @@ class PowerWheelCard extends LitElement {
     const gridPowerIcon = config.grid_power_icon ? config.grid_power_icon
       : (gridPowerState && gridPowerState.attributes.icon ? gridPowerState.attributes.icon : 'mdi:flash-circle');
 
+    let homePowerState;
     let homePowerStateStr;
     if (config.home_power_entity) { // home power value by sensor
-      const homePowerState = hass.states[config.home_power_entity];
+      homePowerState = hass.states[config.home_power_entity];
       homePowerStateStr = homePowerState ? parseFloat(homePowerState.state).toFixed(this.decimals) : 'unavailable';
     } else { // home power value by calculation
       homePowerStateStr = solarPowerState && gridPowerState
@@ -70,6 +71,9 @@ class PowerWheelCard extends LitElement {
           text-align: center;
           width: 150px;
         }
+        ha-card .cell.power {
+          cursor: pointer;
+        }
         ha-icon {
           transition: color 0.3s ease-in-out, filter 0.3s ease-in-out;
           color: var(--paper-item-icon-color, #44739e);
@@ -88,7 +92,7 @@ class PowerWheelCard extends LitElement {
           ${this.title}
         </div>
         <div class="row">
-          <div class="cell">
+          <div class="cell power" on-click="${e => this._handleClick(e, solarPowerState)}">
             <ha-icon icon="${solarPowerIcon}"></ha-icon>
             <br/>${solarPowerStateStr} ${unitStr}
           </div>
@@ -102,20 +106,33 @@ class PowerWheelCard extends LitElement {
           </div>
         </div>
         <div class="row">
-          <div class="cell">
+          <div class="cell power" on-click="${e => this._handleClick(e, gridPowerState)}">
             <ha-icon icon="${gridPowerIcon}"></ha-icon>
             <br/>${gridPowerStateStr} ${unitStr}
           </div>
           <div class="cell">
             <ha-icon class$="${grid2homeClass}" icon="mdi:arrow-right"></ha-icon>
           </div>
-          <div class="cell">
+          <div class="cell power" on-click="${e => this._handleClick(e, homePowerState)}">
             <ha-icon icon="${homePowerIcon}"></ha-icon>
             <br/>${homePowerStateStr} ${unitStr}
           </div>
         </div>
       </ha-card>
     `;
+  }
+
+  _handleClick(ev, stateObj) {
+    if (!stateObj) {
+      return;
+    }
+    const event = new Event('hass-more-info', {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    });
+    event.detail = { entityId: stateObj.entity_id };
+    this.shadowRoot.dispatchEvent(event);
   }
 
   setConfig(config) {


### PR DESCRIPTION
## 0.0.3
### New features
* Added `color_power_icons` as optional boolean card parameter to color the power icons or not (=default). Yellow for consuming, green for producing.
With the new optional card parameters `consuming_color` and `producing_color` you can choose your own colors.
* Click on the power icons to open the more-info modals of your sensors.
* Support for [custom_updater](https://github.com/custom-components/custom_updater) custom component.
### Improvements
* Performance. Moved some code to run it only after config changes.
* Better syntax for 'Example requirements configuration' in readme.
* Icon for home power can also be set via `customize:` sensor settings now.
