### PR TITLE
Release 0.0.11

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,7 @@ labels: ''
 assignees: ''
 
 ---
+I have read the wiki about [what to try first](https://github.com/gurbyz/custom-cards-lovelace/wiki/Before-submitting-an-issue-report) before creating a bug report.
 
 **Which custom card does give you issues?**
 power-wheel-card
@@ -15,7 +16,7 @@ power-wheel-card
 **Which version of the card do you use?**
 
 **Describe the bug**
-A clear and concise description of what the bug is. Paste evt. error messages.
+A clear and concise description of what the bug is. Paste any error messages.
 
 **Configuration of the card**
 Copy the complete configuration of the card, even if you think it isn't relevant.
@@ -26,8 +27,7 @@ Copy the complete configuration of the card, even if you think it isn't relevant
 ```
 
 **Dev console debug output**
-Copy the complete output of the card that is logged to your dev console when the card is in *debug mode*.
-To activate debug mode add `debug: true` to your card parameters. To open the developer console you can press F12 in most browsers.
+Add `debug: true` to your card parameters. Copy the complete output of the card that is logged to your dev console.
 
 Example: power-wheel-cardVersion: 0.0.10Lovelace resource: power-wheel-card.js?v=0.0.10HA version: 0.87.1Report issues here: ...etc...
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,20 +1,18 @@
 ---
 name: Bug report
-about: Create a report to help me improve
+about: Create a report to help me improve. Please read the [wiki](https://github.com/gurbyz/custom-cards-lovelace/wiki/Before-submitting-an-issue-report) first.
 title: ''
 labels: ''
 assignees: ''
 
 ---
 
-**Which card does give you issues?**
+**Which custom card does give you issues?**
 power-wheel-card
 
 **Which version of HA do you use?**
-Example: 0.87.1
 
 **Which version of the card do you use?**
-Example: 0.0.10
 
 **Describe the bug**
 A clear and concise description of what the bug is. Paste evt. error messages.
@@ -27,8 +25,8 @@ Copy the complete configuration of the card, even if you think it isn't relevant
     ...etc...
 ```
 
-**Developer console debug output**
-Copy the complete output of the card that is logged to your developer console when the card is in debug mode.
+**Dev console debug output**
+Copy the complete output of the card that is logged to your dev console when the card is in *debug mode*.
 To activate debug mode add `debug: true` to your card parameters. To open the developer console you can press F12 in most browsers.
 
 Example: power-wheel-cardVersion: 0.0.10Lovelace resource: power-wheel-card.js?v=0.0.10HA version: 0.87.1Report issues here: ...etc...

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /bower_components
 /node_modules
 package-lock.json
+/coverage

--- a/custom_updater.json
+++ b/custom_updater.json
@@ -1,7 +1,7 @@
 {
   "power-wheel-card": {
-    "updated_at": "2019-02-19",
-    "version": "0.0.11-dev",
+    "updated_at": "2019-03-03",
+    "version": "0.0.11",
     "remote_location": "https://raw.githubusercontent.com/gurbyz/custom-cards-lovelace/master/power-wheel-card/power-wheel-card.js",
     "visit_repo": "https://github.com/gurbyz/custom-cards-lovelace/tree/master/power-wheel-card",
     "changelog": "https://github.com/gurbyz/custom-cards-lovelace/blob/master/power-wheel-card/CHANGELOG.md"

--- a/custom_updater.json
+++ b/custom_updater.json
@@ -1,7 +1,7 @@
 {
   "power-wheel-card": {
     "updated_at": "2019-02-19",
-    "version": "0.0.10",
+    "version": "0.0.11-dev",
     "remote_location": "https://raw.githubusercontent.com/gurbyz/custom-cards-lovelace/master/power-wheel-card/power-wheel-card.js",
     "visit_repo": "https://github.com/gurbyz/custom-cards-lovelace/tree/master/power-wheel-card",
     "changelog": "https://github.com/gurbyz/custom-cards-lovelace/blob/master/power-wheel-card/CHANGELOG.md"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
   "scripts": {
     "test": "wct"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "wct"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gurbyz/custom-cards-lovelace.git"
@@ -24,6 +29,7 @@
   },
   "homepage": "https://github.com/gurbyz/custom-cards-lovelace#readme",
   "devDependencies": {
+    "husky": "^1.3.1",
     "lit-element": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/gurbyz/custom-cards-lovelace#readme",
   "devDependencies": {
     "husky": "^1.3.1",
-    "lit-element": "^2.0.0"
+    "lit-element": "^2.0.0",
+    "wct-istanbub": "^0.2.9"
   }
 }

--- a/power-wheel-card/CHANGELOG.md
+++ b/power-wheel-card/CHANGELOG.md
@@ -3,9 +3,11 @@ Changelog
 ## 0.0.11-dev
 ### New features
 * Support for one (nett) grid power sensor.
-Some setups don't have separate sensors for grid power consumption and grid power production.
+Some setups don't have separate sensors for grid power consumption (from the grid) and grid power production (to the grid).
 Previously you had to make an extra template sensor for this.
-The polarity of `grid_power_entity` has to be positive for producing to the grid and negative for consuming from the grid. 
+  * Use card parameter `grid_power_entity`.
+The polarity of this parameter default has to be positive for producing (to the grid) and negative for consuming (from the grid).
+  * Use the new card parameter `grid_power_production_is_positive` to switch the polarity if your (one, nett) `grid_power_entity` hasn't the requested polarity. 
 ### Improvements
 * Arrows will reverse when their value becomes negative.
 (Particular solar power sensors start consuming when there is no sun.)
@@ -20,7 +22,7 @@ The changed polarity is visible only when `color_icons` is set to `false`, becau
 If you don't want colored icons and see negative values, you have to set the parameter to `false` explicitly.
 * Added user agent to the debug output.
 * Automated testing before each commit.
-* Added tests to get a good functional and code coverage. 378 tests now.
+* Added tests to get a good functional and code coverage. 529 tests now.
 
 ## 0.0.10
 ### New features

--- a/power-wheel-card/CHANGELOG.md
+++ b/power-wheel-card/CHANGELOG.md
@@ -1,6 +1,6 @@
 Changelog
 ====
-## 0.0.11-dev
+## 0.0.11
 ### New features
 * Support for one (nett) grid power sensor.
 Some setups don't have separate sensors for grid power consumption (from the grid) and grid power production (to the grid).

--- a/power-wheel-card/CHANGELOG.md
+++ b/power-wheel-card/CHANGELOG.md
@@ -2,16 +2,20 @@ Changelog
 ====
 ## 0.0.11-dev
 ### Improvements
-* When `color_icons` is set to `true` the Solar, Grid and Home values always are displayed as positive values,
+* Arrows will reverse when their value becomes negative.
+(Particular solar power sensors start consuming when there is no sun.)
+The values next to arrows are positive always now. 
+* On coloring the *solar*, *grid* and *home* icons, polarity of their values ('+' when producing, '-' when consuming) and sign of their values ('+' or '-'):
+  * When `color_icons` is set to `true` the Solar, Grid and Home values always are displayed as positive values,
 because the color of the icon represents the plus or minus sign already. 
-* The polarity of the values for Grid and Home is switched for better consistency throughout the card.
+  * The polarity of the values for Grid and Home is switched for better consistency throughout the card.
 The polarity of the colors stayed the same.
-This is visible only when `color_icons` is set to `false`, because negative values only are displayed then.
-* Card parameter `color_icons` is now default `true`.
+The changed polarity is visible only when `color_icons` is set to `false`, because negative values are displayed then only.
+  * Card parameter `color_icons` is now default `true`.
 If you don't want colored icons and see negative values, you have to set the parameter to `false` explicitly.
 * Added user agent to the debug output.
 * Automated testing before each commit.
-* Added tests to get a good functional and code coverage. 345 tests now.
+* Added tests to get a good functional and code coverage. 378 tests now.
 
 ## 0.0.10
 ### New features

--- a/power-wheel-card/CHANGELOG.md
+++ b/power-wheel-card/CHANGELOG.md
@@ -5,12 +5,12 @@ Changelog
 * Support for one (nett) grid power sensor.
 Some setups don't have separate sensors for grid power consumption (from the grid) and grid power production (to the grid).
 Previously you had to make an extra template sensor for this.
-  * Use card parameter `grid_power_entity`.
+  * Use current card parameter `grid_power_entity` to supply your input for the card.
 The polarity of this parameter default has to be positive for producing (to the grid) and negative for consuming (from the grid).
   * Use the new card parameter `grid_power_production_is_positive` to switch the polarity if your (one, nett) `grid_power_entity` hasn't the requested polarity. 
 ### Improvements
 * Arrows will reverse when their value becomes negative.
-(Particular solar power sensors start consuming when there is no sun.)
+(E.g. solar panel inverters start consuming when there is no sun and some users have a sensor that detects this.)
 The values next to arrows are positive always now. 
 * On coloring the *solar*, *grid* and *home* icons, polarity of their values ('+' when producing, '-' when consuming) and sign of their values ('+' or '-'):
   * When `color_icons` is set to `true` the Solar, Grid and Home values always are displayed as positive values,
@@ -22,7 +22,7 @@ The changed polarity is visible only when `color_icons` is set to `false`, becau
 If you don't want colored icons and see negative values, you have to set the parameter to `false` explicitly.
 * Added user agent to the debug output.
 * Automated testing before each commit.
-* Added tests to get a good functional and code coverage. 529 tests now.
+* Added tests to get a good functional and code coverage. There are 529 tests now.
 
 ## 0.0.10
 ### New features

--- a/power-wheel-card/CHANGELOG.md
+++ b/power-wheel-card/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 ## 0.0.11-dev
 ### Improvements
 * Added user agent to the debug output.
-* Added 90 tests.
+* Is automatically tested with 241 tests before each commit.
 
 ## 0.0.10
 ### New features

--- a/power-wheel-card/CHANGELOG.md
+++ b/power-wheel-card/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 ====
 ## 0.0.11-dev
+### New features
+* Support for one (nett) grid power sensor.
+Some setups don't have separate sensors for grid power consumption and grid power production.
+Previously you had to make an extra template sensor for this.
+The polarity of `grid_power_entity` has to be positive for producing to the grid and negative for consuming from the grid. 
 ### Improvements
 * Arrows will reverse when their value becomes negative.
 (Particular solar power sensors start consuming when there is no sun.)

--- a/power-wheel-card/CHANGELOG.md
+++ b/power-wheel-card/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 ====
+## 0.0.11-dev
+### Improvements
+* Added user agent to the debug output.
+
 ## 0.0.10
 ### New features
 * New `debug` parameter for logging debug information in the console of the browser.

--- a/power-wheel-card/CHANGELOG.md
+++ b/power-wheel-card/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 ## 0.0.11-dev
 ### Improvements
 * Added user agent to the debug output.
+* Added 90 tests.
 
 ## 0.0.10
 ### New features

--- a/power-wheel-card/CHANGELOG.md
+++ b/power-wheel-card/CHANGELOG.md
@@ -2,8 +2,16 @@ Changelog
 ====
 ## 0.0.11-dev
 ### Improvements
+* When `color_icons` is set to `true` the Solar, Grid and Home values always are displayed as positive values,
+because the color of the icon represents the plus or minus sign already. 
+* The polarity of the values for Grid and Home is switched for better consistency throughout the card.
+The polarity of the colors stayed the same.
+This is visible only when `color_icons` is set to `false`, because negative values only are displayed then.
+* Card parameter `color_icons` is now default `true`.
+If you don't want colored icons and see negative values, you have to set the parameter to `false` explicitly.
 * Added user agent to the debug output.
-* Is automatically tested with 279 tests before each commit.
+* Automated testing before each commit.
+* Added tests to get a good functional and code coverage. 345 tests now.
 
 ## 0.0.10
 ### New features

--- a/power-wheel-card/CHANGELOG.md
+++ b/power-wheel-card/CHANGELOG.md
@@ -6,13 +6,26 @@ Changelog
 Some setups don't have separate sensors for grid power consumption (from the grid) and grid power production (to the grid).
 Previously you had to make an extra template sensor for this.
   * Use current card parameter `grid_power_entity` to supply your input for the card.
-The polarity of this parameter default has to be positive for producing (to the grid) and negative for consuming (from the grid).
-  * Use the new card parameter `grid_power_production_is_positive` to switch the polarity if your (one, nett) `grid_power_entity` hasn't the requested polarity. 
+Default the polarity of this parameter has to be positive for producing (to the grid) and negative for consuming (from the grid). 
+* Support for one (nett) grid energy sensor.
+Some setups don't have separate sensors for grid energy consumption (from the grid) and grid energy production (to the grid).
+Previously you were not able to use the *energy view*.
+  * Use current card parameter `grid_energy_entity` to supply your input for the card.
+  * Use current card parameter `home_energy_entity` to supply your input for the card. This extra parameter is needed because the consumed energy of your home can't be calculated if you only have one grid energy sensor.
+  * Default the polarity of these parameters has to be positive for producing (to the grid) and negative for consuming (from the grid).
+  * Nb. There still won't be active arrows in the *energy view* nor values near the arrows.
+This is because you supply too less information to calculate these values.
+Power-wheel-card can't do magic.
+* Support for switching the polarity of `grid_power_entity`, `grid_energy_entity` and `home_energy_entity`.
+Default the polarity of these parameters has to be positive for producing (to the grid) and negative for consuming (from the grid).
+  * You can switch the polarity of all these 3 entities with the new card parameter `production_is_positive`.
+  * Nb. The parameter is switching the polarity of exactly only the 3 mentioned input parameters. All other input parameters are not affected.
+  * Nb. The parameter is switching the polarity of **input** values to be able to use them in calculations. Negative output values (i.e. displayed values) always represent consuming (from the grid).  
 ### Improvements
 * Arrows will reverse when their value becomes negative.
 (E.g. solar panel inverters start consuming when there is no sun and some users have a sensor that detects this.)
-The values next to arrows are positive always now. 
-* On coloring the *solar*, *grid* and *home* icons, polarity of their values ('+' when producing, '-' when consuming) and sign of their values ('+' or '-'):
+The values next to arrows always are positive now. 
+* About coloring the *solar*, *grid* and *home* icons, polarity of their values ('+' when producing, '-' when consuming) and sign of their values ('+' or '-'):
   * When `color_icons` is set to `true` the Solar, Grid and Home values always are displayed as positive values,
 because the color of the icon represents the plus or minus sign already. 
   * The polarity of the values for Grid and Home is switched for better consistency throughout the card.
@@ -22,7 +35,7 @@ The changed polarity is visible only when `color_icons` is set to `false`, becau
 If you don't want colored icons and see negative values, you have to set the parameter to `false` explicitly.
 * Added user agent to the debug output.
 * Automated testing before each commit.
-* Added tests to get a good functional and code coverage. There are 529 tests now.
+* Added tests to get a good functional and code coverage. There are 627 tests now.
 
 ## 0.0.10
 ### New features

--- a/power-wheel-card/CHANGELOG.md
+++ b/power-wheel-card/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 ## 0.0.11-dev
 ### Improvements
 * Added user agent to the debug output.
-* Is automatically tested with 241 tests before each commit.
+* Is automatically tested with 279 tests before each commit.
 
 ## 0.0.10
 ### New features

--- a/power-wheel-card/README.md
+++ b/power-wheel-card/README.md
@@ -2,7 +2,7 @@ power-wheel-card
 ====
 
 An intuïtive way to represent the power and energy that your home is consuming or producing.
-> This component is discussed [here](https://community.home-assistant.io/t/lovelace-power-wheel-card/82374) on the Home Assistant forum.
+> This component is discussed [here](https://community.home-assistant.io/t/lovelace-power-wheel-card/82374) on the Home Assistant forum. There's also a [wiki](https://github.com/gurbyz/custom-cards-lovelace/wiki/Before-submitting-an-issue-report) on GitHub.
 
 ## Features
 Features of the custom power-wheel-card:

--- a/power-wheel-card/README.md
+++ b/power-wheel-card/README.md
@@ -160,7 +160,6 @@ views:
         solar_power_entity: sensor.YOUR_SOLAR_POWER_SENSOR
         grid_power_consumption_entity: sensor.YOUR_GRID_POWER_CONSUMPTION_SENSOR
         grid_power_production_entity: sensor.YOUR_GRID_POWER_PRODUCTION_SENSOR
-        color_icons: true
 ```
 
 There are many more card parameters available, but it's advised to start with this simple setup to get things running. 
@@ -188,7 +187,7 @@ There are many more card parameters available, but it's advised to start with th
 |power_decimals|integer|optional|`0`|Number of decimals for the power values.|
 |energy_decimals|integer|optional|`3`|Number of decimals for the energy values.|
 |money_decimals|integer|optional|`2`|Number of decimals for the money values.|
-|color_icons|boolean|optional|`false`|To color the consuming icons green and the producing icons yellow. This setting only is affecting the three big icons for *solar*, *home* and *grid*. The arrows have colors by default.|
+|color_icons|boolean|optional|`true`|To color the consuming icons green and the producing icons yellow. Icon values will have an absolute value. This setting only is affecting the three big icons for *solar*, *home* and *grid*. The arrows have colors by default.|
 |consuming_color|string|optional|The yellow color for `--label-badge-yellow` from your theme. If not available, then `"#f4b400"` will be used.|CSS color code for consuming power icons if `color_icons` is set to `true`. Examples: `"orange"`, `"#ffcc66"` or `"rgb(200,100,50)"`. Don't forget the quotation marks when using the `#` color notation.|
 |producing_color|string|optional|The green color for `--label-badge-green` from your theme. If not available, then `"#0da035"` will be used.|CSS color code for producing power icons if `color_icons` is set to `true`.|
 |initial_view|string|optional|`"power"`|The initial view that will displayed. Allowed values are `"power"` for *power view*, `"energy"` for *energy view* and `"money"` for *money view*.|

--- a/power-wheel-card/README.md
+++ b/power-wheel-card/README.md
@@ -28,6 +28,8 @@ Features of the custom power-wheel-card:
   E.g. if your solar power panels produce power, the arrow from solar to home turns active.
   And if your solar power panels produce enough power to deliver some back to the grid, the arrow from solar to grid turns active.
 * Arrows can have values next to them. Zero values are suppressed. And values on the arrows are visible only when relevant. E.g. on a sunny day when part of your produced solar panel energy was returned to the grid and the other part was consumed by your home.
+* Has support for setups that don't have separated grid sensors for consuming and producing.
+  In these setups arrow values and arrow coloring are not available in *energy view* and *money view* due to lack of input details.
 * Optionally uses icons of your own choice, which can be set by card parameters or taken from your `customize:` sensor settings.
 * Optionally colors the consuming icons yellow and the producing icons green. You can choose your own colors for consuming and producing.
 * Works for default theme and custom themes that use [standard CSS vars](https://github.com/home-assistant/home-assistant-polymer/blob/master/src/resources/ha-style.js).
@@ -168,19 +170,17 @@ There are many more card parameters available, but it's advised to start with th
 
 | Parameter | Type | Mandatory? | Default | Description |
 |-----------|------|------------|---------|-------------|
-|type|string|**required**||Type of the card. Use `"custom:power-wheel-card"`.|
+|type|string|**required**| |Type of the card. Use `"custom:power-wheel-card"`.|
 |title|string|optional|`"Power wheel"`|Title of the card in all views, if not overridden with a title per view.|
 |title_power|string|optional|Value of `title`.|Title of the card in *power view*.|
 |title_energy|string|optional|Value of `title`.|Title of the card in *energy view*.|
 |title_money|string|optional|Value of `title`.|Title of the card in *money view*.|
-|solar_power_entity|string|**required**||Entity id of your solar power sensor. E.g. `sensor.YOUR_SOLAR_POWER_SENSOR`. See requirements above.|
-|grid_power_consumption_entity (A)|string|preferred, together with B||Entity id of your sensor for power that you are consuming from the grid. E.g. `sensor.YOUR_GRID_POWER_CONSUMPTION_SENSOR`. See requirements above.|
-|grid_power_production_entity (B)|string|preferred, together with A||Entity id of your sensor for power that you are producing to the grid. E.g. `sensor.YOUR_GRID_POWER_PRODUCTION_SENSOR`. See requirements above.|
-|grid_power_entity (C)|string|optional, but required if you don't have A and B||Entity id of your nett grid power sensor if you don't have separate sensors for grid power production (to the grid) and grid power consumption (from the grid).|
-|grid_power_production_is_positive|boolean|optional|`true`|If you use `grid_power_entity` (C) you can specify the polarity of this input sensor. Use `true` for producing to the grid has positive values. Use `false` for producing to the grid has negative values.| 
+|solar_power_entity|string|**required**| |Entity id of your solar power sensor. E.g. `sensor.YOUR_SOLAR_POWER_SENSOR`. See requirements above.|
+|grid_power_consumption_entity (A)|string|optional, always together with B| |Entity id of your sensor for power that you are consuming from the grid. E.g. `sensor.YOUR_GRID_POWER_CONSUMPTION_SENSOR`. See requirements above.|
+|grid_power_production_entity (B)|string|optional, always together with A| |Entity id of your sensor for power that you are producing to the grid. E.g. `sensor.YOUR_GRID_POWER_PRODUCTION_SENSOR`. See requirements above.|
 |solar_energy_entity|string|optional|Default the *energy view* will not be enabled.|Entity id of your solar energy sensor. E.g. `sensor.YOUR_SOLAR_ENERGY_SENSOR`. See requirements above.|
-|grid_energy_consumption_entity|string|optional|Default the *energy view* will not be enabled.|Entity id of your sensor for energy that's consumed from the grid. E.g. `sensor.YOUR_GRID_ENERGY_CONSUMPTION_SENSOR`. See requirements above.|
-|grid_energy_production_entity|string|optional|Default the *energy view* will not be enabled.|Entity id of your sensor for energy that's produced to the grid. E.g. `sensor.YOUR_GRID_ENERGY_PRODUCTION_SENSOR`. See requirements above.|
+|grid_energy_consumption_entity (D)|string|optional, always together with E|Default the *energy view* will not be enabled.|Entity id of your sensor for energy that's consumed from the grid. E.g. `sensor.YOUR_GRID_ENERGY_CONSUMPTION_SENSOR`. See requirements above.|
+|grid_energy_production_entity (E)|string|optional, always together with D|Default the *energy view* will not be enabled.|Entity id of your sensor for energy that's produced to the grid. E.g. `sensor.YOUR_GRID_ENERGY_PRODUCTION_SENSOR`. See requirements above.|
 |energy_price|float|optional|Default the *money view* will not be enabled.|The price of your energy per unit of energy. E.g. `0.20`.|
 |money_unit|string|optional|`"€"`|The unit of `energy_price`. This unit will be used for displaying all money values.|
 |solar_icon|string|optional|The icon of your own customized solar sensor(s). If not available, then `"mdi:weather-sunny"` will be used.|Icon for solar power and energy.|
@@ -196,6 +196,15 @@ There are many more card parameters available, but it's advised to start with th
 |initial_auto_toggle_view|boolean|optional|`false`|The initial state of the auto-toggle for views.|
 |auto_toggle_view_period|integer|optional|`10`|Period in seconds between views when auto-toggle for views is turned on.|
 |debug|boolean|optional|`false`|Logs debug information in the console of your browser. Useful when you want to investigate or register an issue.|
+
+Some extra parameters for users who don't have separate grid sensors for producing and consuming:
+
+| Parameter | Type | Mandatory? | Default | Description |
+|-----------|------|------------|---------|-------------|
+|grid_power_entity (C)|string|optional, but required if you don't have A and B| |Entity id of your nett grid power sensor if you don't have separate sensors for grid power production (to the grid) and grid power consumption (from the grid).|
+|grid_energy_entity (F)|string|optional, but required if you don't have D and E and want to use the *energy view*| |Entity id of your nett grid energy sensor if you don't have separate sensors for grid energy production (to the grid) and grid energy consumption (from the grid).|
+|home_energy_entity (G)|string|optional, but required if you don't have D and E and want to use the *energy view*| |Entity id of your home energy sensor if you don't have separate sensors for grid energy production (to the grid) and grid energy consumption (from the grid).|
+|production_is_positive|boolean|optional|`true`|If you use C, F or G you can specify the polarity of these input sensors. Use `true` for producing to the grid has positive values in your input sensor. Use `false` for producing to the grid has negative values.| 
 
 Some extra parameters for advanced users who use dynamic icons in their HA setup and want to use them in the power-wheel-card: 
 

--- a/power-wheel-card/README.md
+++ b/power-wheel-card/README.md
@@ -174,8 +174,10 @@ There are many more card parameters available, but it's advised to start with th
 |title_energy|string|optional|Value of `title`.|Title of the card in *energy view*.|
 |title_money|string|optional|Value of `title`.|Title of the card in *money view*.|
 |solar_power_entity|string|**required**||Entity id of your solar power sensor. E.g. `sensor.YOUR_SOLAR_POWER_SENSOR`. See requirements above.|
-|grid_power_consumption_entity|string|**required**||Entity id of your sensor for power that you are consuming from the grid. E.g. `sensor.YOUR_GRID_POWER_CONSUMPTION_SENSOR`. See requirements above.|
-|grid_power_production_entity|string|**required**||Entity id of your sensor for power that you are producing to the grid. E.g. `sensor.YOUR_GRID_POWER_PRODUCTION_SENSOR`. See requirements above.|
+|grid_power_consumption_entity (A)|string|preferred, together with B||Entity id of your sensor for power that you are consuming from the grid. E.g. `sensor.YOUR_GRID_POWER_CONSUMPTION_SENSOR`. See requirements above.|
+|grid_power_production_entity (B)|string|preferred, together with A||Entity id of your sensor for power that you are producing to the grid. E.g. `sensor.YOUR_GRID_POWER_PRODUCTION_SENSOR`. See requirements above.|
+|grid_power_entity (C)|string|optional, but required if you don't have A and B||Entity id of your nett grid power sensor if you don't have separate sensors for grid power production (to the grid) and grid power consumption (from the grid).|
+|grid_power_production_is_positive|boolean|optional|`true`|If you use `grid_power_entity` (C) you can specify the polarity of this input sensor. Use `true` for producing to the grid has positive values. Use `false` for producing to the grid has negative values.| 
 |solar_energy_entity|string|optional|Default the *energy view* will not be enabled.|Entity id of your solar energy sensor. E.g. `sensor.YOUR_SOLAR_ENERGY_SENSOR`. See requirements above.|
 |grid_energy_consumption_entity|string|optional|Default the *energy view* will not be enabled.|Entity id of your sensor for energy that's consumed from the grid. E.g. `sensor.YOUR_GRID_ENERGY_CONSUMPTION_SENSOR`. See requirements above.|
 |grid_energy_production_entity|string|optional|Default the *energy view* will not be enabled.|Entity id of your sensor for energy that's produced to the grid. E.g. `sensor.YOUR_GRID_ENERGY_PRODUCTION_SENSOR`. See requirements above.|

--- a/power-wheel-card/README.md
+++ b/power-wheel-card/README.md
@@ -42,21 +42,28 @@ Features of the custom power-wheel-card:
 ## Requirements for the *power view*
 1. You need to have a working sensor for your solar power.
    Write down the entity id of this sensor. This is *YOUR_SOLAR_POWER_SENSOR* in the instructions below.
-    - The sensor could have an icon (optional) that will override the default icon in the power-wheel-card if the card parameter `solar_icon` is not used.
+   - The sensor could have an icon (optional) that will override the default icon in the power-wheel-card if the card parameter `solar_icon` is not used.
+   - The sensor state value should be a positive number when producing power.
 
-1. You need to have a working sensor for your grid power consumption (i.e. power you consume from the grid).
-   Write down the entity id of this sensor. This is *YOUR_GRID_POWER_CONSUMPTION_SENSOR* in the instructions below.
-    - Preferably this sensor has the same update interval as the sensor for solar power. (If not, the calculated value for home power can give unreal results sometimes.)
-1. You need to have a working sensor for your grid power production (i.e. power you produce to the grid).
-   Write down the entity id of this sensor. This is *YOUR_GRID_POWER_PRODUCTION_SENSOR* in the instructions below.
-    - Preferably this sensor has the same update interval as the sensor for solar power. (If not, the calculated value for home power can give unreal results sometimes.)
+1. You either need to have (i) separate grid power sensors for consuming and producing OR need to have (ii) one (nett) grid power sensor:
+   1. You need to have a working sensor for your grid power consumption (i.e. power you consume from the grid).
+      Write down the entity id of this sensor. This is *YOUR_GRID_POWER_CONSUMPTION_SENSOR* in the instructions below.
+
+      You need to have a working sensor for your grid power production (i.e. power you produce to the grid).
+      Write down the entity id of this sensor. This is *YOUR_GRID_POWER_PRODUCTION_SENSOR* in the instructions below.
+      - Preferably these sensors have the same update interval as the sensor for solar power. (If not, the calculated value for home power can give unreal results sometimes.)
+      - The sensor state values should be a positive number.
+
+      *OR:*
+   1. You need to have a working sensor for your (nett) grid power.
+      Write down the entity id of this sensor. This is *YOUR_GRID_POWER_SENSOR* in the instructions below.
+      - Default the polarity of this parameter has to be positive for producing (to the grid) and negative for consuming (from the grid).
 1. For all these sensors:
-    - A `unit_of_measurement` has been set up, e.g. `'W'` or `'kW'`.
-    - The `unit_of_measurement` is the same as the other power sensors.
-    - The sensor state should always be parsable to an *int* or - even better - a *float* value.
-    - The sensor state value should be a positive number.
+   - A `unit_of_measurement` has been set up, e.g. `'W'` or `'kW'`.
+   - The `unit_of_measurement` is the same as the other power sensors.
+   - The sensor state should always be parsable to an *int* or - even better - a *float* value.
 
-You don't need a sensor for your (nett) grid power but you can use it if you have it available and want to use its **icon**. The **value** of this sensor will not be used.
+You don't always need a sensor for your (nett) grid power but you can use it if you have it available and want to use its **icon**.
 
 You don't need a sensor for your home power, but you can use it if you have it available and want to use its **icon**. The **value** of this sensor will not be used. 
 
@@ -109,22 +116,33 @@ But if you want the *energy view*:
    Then you are able to see the actual energy costs/savings today in the *money view*.
 1. You need to have a working sensor for your solar energy. 
    Write down the entity id of this sensor. This is *YOUR_SOLAR_ENERGY_SENSOR* in the instructions below.
-    - The sensor could have an icon (optional) that will override the default icon in the power-wheel-card if the card parameter `solar_icon` is not used.
-1. You need to have a working sensor for your grid energy consumption (i.e. energy you consumed from the grid).
-   Write down the entity id of this sensor. This is *YOUR_GRID_ENERGY_CONSUMPTION_SENSOR* in the instructions below.
-    - Preferably this sensor has the same update interval as the sensor for solar energy. (If not, the calculated value for home energy can give unreal results sometimes.)
-1. You need to have a working sensor for your grid energy production (i.e. energy you produced to the grid).
-   Write down the entity id of this sensor. This is *YOUR_GRID_ENERGY_PRODUCTION_SENSOR* in the instructions below.
-    - Preferably this sensor has the same update interval as the sensor for solar energy. (If not, the calculated value for home energy can give unreal results sometimes.)
+   - The sensor could have an icon (optional) that will override the default icon in the power-wheel-card if the card parameter `solar_icon` is not used.
+   - The sensor state value should be a positive number for having produced energy.
+1. You either need to have (i) separate grid energy sensors for consuming and producing OR need to have (ii) one (nett) grid energy sensor and a home energy sensor:
+   1. You need to have a working sensor for your grid energy consumption (i.e. energy you consumed from the grid).
+      Write down the entity id of this sensor. This is *YOUR_GRID_ENERGY_CONSUMPTION_SENSOR* in the instructions below.
+
+      You need to have a working sensor for your grid energy production (i.e. energy you produced to the grid).
+      Write down the entity id of this sensor. This is *YOUR_GRID_ENERGY_PRODUCTION_SENSOR* in the instructions below.
+      - Preferably these sensors have the same update interval as the sensor for solar energy. (If not, the calculated value for home energy can give unreal results sometimes.)
+      - The sensor state values should be a positive number.
+      
+      *OR: (not recommended)*
+   1. You need to have a working sensor for your (nett) grid energy.
+      Write down the entity id of this sensor. This is *YOUR_GRID_ENERGY_SENSOR* in the instructions below.
+
+      You need to have a working sensor for your home energy, because it can't be calculated.
+      Write down the entity id of this sensor. This is *YOUR_HOME_ENERGY_SENSOR* in the instructions below.
+      - Default the polarity of these parameters have to be positive for producing (to the grid) and negative for consuming (from the grid).
+      - Nb. You will lack arrow coloring and arrow values in the *energy view* and *money view* due to supplying too less information to calculate these.      
 1. For all these sensors:
-    - A `unit_of_measurement` has been set up, e.g. `'Wh'` or `'kWh'`.
-    - The `unit_of_measurement` is the same as the other energy sensors.
-    - The sensor state should always be parsable to an *int* or - even better - a *float* value.
-    - The sensor state value should be a positive number.
+   - A `unit_of_measurement` has been set up, e.g. `'Wh'` or `'kWh'`.
+   - The `unit_of_measurement` is the same as the other energy sensors.
+   - The sensor state should always be parsable to an *int* or - even better - a *float* value.
 
-You don't need a sensor for your (nett) grid energy but you can use it if you have it available and want to use its **icon**. The **value** of this sensor will not be used.
+You don't always need a sensor for your (nett) grid energy but you can use it if you have it available and want to use its **icon**.
 
-You don't need a sensor for your home energy, but you can use it if you have it available and want to use its **icon**. The **value** of this sensor will not be used.
+You don't always need a sensor for your home energy, but you can use it if you have it available and want to use its **icon**.
 
 ## Requirements for the *money view*
 The *money view* itself is not required. As a result you don't have to specify any *money view* related card parameters. 
@@ -201,10 +219,10 @@ Some extra parameters for users who don't have separate grid sensors for produci
 
 | Parameter | Type | Mandatory? | Default | Description |
 |-----------|------|------------|---------|-------------|
-|grid_power_entity (C)|string|optional, but required if you don't have A and B| |Entity id of your nett grid power sensor if you don't have separate sensors for grid power production (to the grid) and grid power consumption (from the grid).|
-|grid_energy_entity (F)|string|optional, but required if you don't have D and E and want to use the *energy view*| |Entity id of your nett grid energy sensor if you don't have separate sensors for grid energy production (to the grid) and grid energy consumption (from the grid).|
-|home_energy_entity (G)|string|optional, but required if you don't have D and E and want to use the *energy view*| |Entity id of your home energy sensor if you don't have separate sensors for grid energy production (to the grid) and grid energy consumption (from the grid).|
-|production_is_positive|boolean|optional|`true`|If you use C, F or G you can specify the polarity of these input sensors. Use `true` for producing to the grid has positive values in your input sensor. Use `false` for producing to the grid has negative values.| 
+|grid_power_entity (C)|string|optional, but required if you don't have A and B| |Entity id of your nett grid power sensor if you don't have separate sensors for grid power production (to the grid) and grid power consumption (from the grid). E.g. `sensor.YOUR_GRID_POWER_SENSOR`.|
+|grid_energy_entity (F)|string|optional, but required if you don't have D and E and want to use the *energy view*| |Entity id of your nett grid energy sensor if you don't have separate sensors for grid energy production (to the grid) and grid energy consumption (from the grid). E.g. `sensor.YOUR_GRID_ENERGY_SENSOR`.|
+|home_energy_entity (G)|string|optional, but required if you don't have D and E and want to use the *energy view*| |Entity id of your home energy sensor if you don't have separate sensors for grid energy production (to the grid) and grid energy consumption (from the grid). E.g. `sensor.YOUR_HOME_ENERGY_SENSOR`.|
+|production_is_positive|boolean|optional|`true`|If you use C, F or G you can specify the polarity of these input sensors. Use `true` for producing to the grid has positive values in your input sensors. Use `false` for producing to the grid has negative values.| 
 
 Some extra parameters for advanced users who use dynamic icons in their HA setup and want to use them in the power-wheel-card: 
 

--- a/power-wheel-card/power-wheel-card.js
+++ b/power-wheel-card/power-wheel-card.js
@@ -5,7 +5,7 @@
  *
  */
 
-const __VERSION = "0.0.11-dev";
+const __VERSION = "0.0.11";
 
 const LitElement = Object.getPrototypeOf(customElements.get("home-assistant-main"));
 const html = LitElement.prototype.html;

--- a/power-wheel-card/power-wheel-card.js
+++ b/power-wheel-card/power-wheel-card.js
@@ -170,11 +170,13 @@ class PowerWheelCard extends LitElement {
     if (this.views[this.view].twoGridSensors) {
       const gridConsumptionStateObj = this.hass.states[grid_consumption_entity];
       return gridConsumptionStateObj ? parseFloat(gridConsumptionStateObj.state) : undefined;
-    } else {
+    } else if(this.view === 'power') {
       const gridStateObj = this.hass.states[grid_entity];
       const value = gridStateObj
         ? parseFloat(gridStateObj.state) * this.config.grid_power_production_is_positive : undefined;
       return value < 0 ? Math.abs(value) : 0;
+    } else {
+      return 0;
     }
   }
 
@@ -182,11 +184,13 @@ class PowerWheelCard extends LitElement {
     if (this.views[this.view].twoGridSensors) {
       const gridProductionStateObj = this.hass.states[grid_production_entity];
       return gridProductionStateObj ? parseFloat(gridProductionStateObj.state) : undefined;
-    } else {
+    } else if(this.view === 'power') {
       const gridStateObj = this.hass.states[grid_entity];
       const value = gridStateObj
         ? parseFloat(gridStateObj.state) * this.config.grid_power_production_is_positive : undefined;
       return value > 0 ? value : 0;
+    } else {
+      return 0;
     }
   }
 
@@ -202,13 +206,22 @@ class PowerWheelCard extends LitElement {
   }
 
   _calculateHomeValue() {
-    return typeof this.data.solar.val !== 'undefined' && typeof this.data.grid.val !== 'undefined'
-      ? this.data.grid.val - this.data.solar.val : undefined;
+    if (this.views[this.view].twoGridSensors || this.view === 'power') {
+      return typeof this.data.solar.val !== 'undefined' && typeof this.data.grid.val !== 'undefined'
+        ? this.data.grid.val - this.data.solar.val : undefined;
+    } else {
+      // todo: get home value from separate sensor?
+      return 0;
+    }
   }
 
   _calculateSolar2HomeValue() {
-    return typeof this.data.solar.val !== 'undefined' && typeof this.data.solar2grid.val !== 'undefined'
-      ? this.data.solar.val - this.data.solar2grid.val : undefined;
+    if (this.views[this.view].twoGridSensors || this.view === 'power') {
+      return typeof this.data.solar.val !== 'undefined' && typeof this.data.solar2grid.val !== 'undefined'
+        ? this.data.solar.val - this.data.solar2grid.val : undefined;
+    } else {
+      return 0;
+    }
   }
 
   _logConsole(message) {
@@ -497,9 +510,11 @@ class PowerWheelCard extends LitElement {
       "solar_power_entity",
       "grid_power_consumption_entity",
       "grid_power_production_entity",
+      "grid_power_entity",
       "solar_energy_entity",
       "grid_energy_consumption_entity",
       "grid_energy_production_entity",
+      "grid_energy_entity",
     ].reduce((sensors, cardParameter) => {
       if (config.hasOwnProperty(cardParameter)) {
         sensors.push(config[cardParameter]);

--- a/power-wheel-card/power-wheel-card.js
+++ b/power-wheel-card/power-wheel-card.js
@@ -172,7 +172,8 @@ class PowerWheelCard extends LitElement {
       return gridConsumptionStateObj ? parseFloat(gridConsumptionStateObj.state) : undefined;
     } else {
       const gridStateObj = this.hass.states[grid_entity];
-      const value = gridStateObj ? parseFloat(gridStateObj.state) : undefined;
+      const value = gridStateObj
+        ? parseFloat(gridStateObj.state) * this.config.grid_power_production_is_positive : undefined;
       return value < 0 ? Math.abs(value) : 0;
     }
   }
@@ -183,7 +184,8 @@ class PowerWheelCard extends LitElement {
       return gridProductionStateObj ? parseFloat(gridProductionStateObj.state) : undefined;
     } else {
       const gridStateObj = this.hass.states[grid_entity];
-      const value = gridStateObj ? parseFloat(gridStateObj.state) : undefined;
+      const value = gridStateObj
+        ? parseFloat(gridStateObj.state) * this.config.grid_power_production_is_positive : undefined;
       return value > 0 ? value : 0;
     }
   }
@@ -194,7 +196,8 @@ class PowerWheelCard extends LitElement {
         ? this.data.solar2grid.val - this.data.grid2home.val : undefined;
     } else {
       const gridStateObj = this.hass.states[grid_entity];
-      return gridStateObj ? parseFloat(gridStateObj.state) : undefined;
+      return gridStateObj
+        ? parseFloat(gridStateObj.state) * this.config.grid_power_production_is_positive : undefined;
     }
   }
 
@@ -520,6 +523,8 @@ class PowerWheelCard extends LitElement {
     if (config.grid_power_consumption_entity && !config.grid_power_production_entity) {
       throw new Error('You need to define a grid_power_production_entity');
     }
+    config.grid_power_production_is_positive = config.grid_power_production_is_positive !== false;
+    config.grid_power_production_is_positive = config.grid_power_production_is_positive ? 1 : -1;
     config.title = config.title ? config.title : 'Power wheel';
     config.title_power = config.title_power ? config.title_power : config.title;
     config.title_energy = config.title_energy ? config.title_energy : config.title;

--- a/power-wheel-card/power-wheel-card.js
+++ b/power-wheel-card/power-wheel-card.js
@@ -124,19 +124,19 @@ class PowerWheelCard extends LitElement {
   
   /* Card functions */
 
-  _generateClass(producingIsPositive, value) {
-    if (producingIsPositive) {
-      return value > 0 ? 'producing' : ((value < 0) ? 'consuming' : 'inactive');
-    } else {
-      return value > 0 ? 'consuming' : ((value < 0) ? 'producing' : 'inactive');
-    }
+  _generateClass(value) {
+    return value > 0 ? 'producing' : ((value < 0) ? 'consuming' : 'inactive');
   }
 
-  _makePositionObject(val, entity, configIcon, defaultIcon, decimals, producingIsPositive) {
-    const valueStr = typeof val === 'undefined' ? 'unavailable' : val.toFixed(decimals);
+  _generateValueStr(value, decimals) {
+    return this.config.color_icons ? Math.abs(value).toFixed(decimals): value.toFixed(decimals);
+  }
+
+  _makePositionObject(val, entity, configIcon, defaultIcon, decimals) {
+    const valueStr = typeof val === 'undefined' ? 'unavailable' : this._generateValueStr(val, decimals);
     const stateObj = this.hass.states[entity];
     const icon = configIcon ? configIcon : (stateObj && stateObj.attributes.icon ? stateObj.attributes.icon : defaultIcon);
-    const classValue = this._generateClass(producingIsPositive, val);
+    const classValue = this._generateClass(val);
 
     return {
       stateObj,
@@ -180,12 +180,12 @@ class PowerWheelCard extends LitElement {
 
   _calculateGridValue() {
     return typeof this.data.grid2home.val !== 'undefined' && typeof this.data.solar2grid.val !== 'undefined'
-      ? this.data.grid2home.val - this.data.solar2grid.val : undefined;
+      ? this.data.solar2grid.val - this.data.grid2home.val : undefined;
   }
 
   _calculateHomeValue() {
     return typeof this.data.solar.val !== 'undefined' && typeof this.data.grid.val !== 'undefined'
-      ? this.data.solar.val + this.data.grid.val : undefined;
+      ? this.data.grid.val - this.data.solar.val : undefined;
   }
 
   _calculateSolar2HomeValue() {
@@ -319,11 +319,11 @@ class PowerWheelCard extends LitElement {
       this.data.home.val = this._calculateHomeValue();
       this.data.solar2home.val = this._calculateSolar2HomeValue();
       this.data.solar = this._makePositionObject(this.data.solar.val, this.config.solar_energy_entity, this.config.solar_icon,
-        'mdi:weather-sunny', this.config.money_decimals, true);
+        'mdi:weather-sunny', this.config.money_decimals);
       this.data.grid = this._makePositionObject(this.data.grid.val, this.config.grid_energy_entity, this.config.grid_icon,
-        'mdi:transmission-tower', this.config.money_decimals, false);
+        'mdi:transmission-tower', this.config.money_decimals);
       this.data.home = this._makePositionObject(this.data.home.val, this.config.home_energy_entity, this.config.home_icon,
-        'mdi:home', this.config.money_decimals, false);
+        'mdi:home', this.config.money_decimals);
       this.data.solar2grid = this._makeArrowObject(this.data.solar2grid.val, false, 'mdi:arrow-bottom-left', this.config.money_decimals);
       this.data.solar2home = this._makeArrowObject(this.data.solar2home.val, false, 'mdi:arrow-bottom-right', this.config.money_decimals);
       this.data.grid2home = this._makeArrowObject(this.data.grid2home.val, false, 'mdi:arrow-right', this.config.money_decimals);
@@ -335,11 +335,11 @@ class PowerWheelCard extends LitElement {
       this.data.home.val = this._calculateHomeValue();
       this.data.solar2home.val = this._calculateSolar2HomeValue();
       this.data.solar = this._makePositionObject(this.data.solar.val, this.config.solar_energy_entity, this.config.solar_icon,
-          'mdi:weather-sunny', this.config.energy_decimals, true);
+          'mdi:weather-sunny', this.config.energy_decimals);
       this.data.grid = this._makePositionObject(this.data.grid.val, this.config.grid_energy_entity, this.config.grid_icon,
-          'mdi:transmission-tower', this.config.energy_decimals, false);
+          'mdi:transmission-tower', this.config.energy_decimals);
       this.data.home = this._makePositionObject(this.data.home.val, this.config.home_energy_entity, this.config.home_icon,
-          'mdi:home', this.config.energy_decimals, false);
+          'mdi:home', this.config.energy_decimals);
       this.data.solar2grid = this._makeArrowObject(this.data.solar2grid.val, this.config.grid_energy_production_entity, 'mdi:arrow-bottom-left', this.config.energy_decimals);
       this.data.solar2home = this._makeArrowObject(this.data.solar2home.val, false, 'mdi:arrow-bottom-right', this.config.energy_decimals);
       this.data.grid2home = this._makeArrowObject(this.data.grid2home.val, this.config.grid_energy_consumption_entity, 'mdi:arrow-right', this.config.energy_decimals);
@@ -351,11 +351,11 @@ class PowerWheelCard extends LitElement {
       this.data.home.val = this._calculateHomeValue();
       this.data.solar2home.val = this._calculateSolar2HomeValue();
       this.data.solar = this._makePositionObject(this.data.solar.val, this.config.solar_power_entity, this.config.solar_icon,
-          'mdi:weather-sunny', this.config.power_decimals, true);
+          'mdi:weather-sunny', this.config.power_decimals);
       this.data.grid = this._makePositionObject(this.data.grid.val, this.config.grid_power_entity, this.config.grid_icon,
-          'mdi:transmission-tower', this.config.power_decimals, false);
+          'mdi:transmission-tower', this.config.power_decimals);
       this.data.home = this._makePositionObject(this.data.home.val, this.config.home_power_entity, this.config.home_icon,
-          'mdi:home', this.config.power_decimals, false);
+          'mdi:home', this.config.power_decimals);
       this.data.solar2grid = this._makeArrowObject(this.data.solar2grid.val, this.config.grid_power_production_entity, 'mdi:arrow-bottom-left', this.config.power_decimals);
       this.data.solar2home = this._makeArrowObject(this.data.solar2home.val, false, 'mdi:arrow-bottom-right', this.config.power_decimals);
       this.data.grid2home = this._makeArrowObject(this.data.grid2home.val, this.config.grid_power_consumption_entity, 'mdi:arrow-right', this.config.power_decimals);
@@ -414,7 +414,7 @@ class PowerWheelCard extends LitElement {
             @click="${cellObj.hasSensor ? () => this._handleClick(cellObj.stateObj) : () => {}}"
             title="${cellObj.hasSensor ? `More info${cellObj.stateObj.attributes.friendly_name ? ':\n' + cellObj.stateObj.attributes.friendly_name : ''}` : ''}">
         <ha-icon id="icon-${id}" class="${cellObj.classValue}" icon="${cellObj.icon}"></ha-icon>
-        <div id="value-${id}" class="value">${cellType === 'arrow' && (cellObj.val === 0 || cellObj.val === hideValue) ? '' : cellObj.valueStr}</div>
+        <div id="value-${id}" class="value">${cellType === 'arrow' && (cellObj.val === 0 || cellObj.val === Math.abs(hideValue)) ? '' : cellObj.valueStr}</div>
       </div>
     `;
   }
@@ -506,7 +506,7 @@ class PowerWheelCard extends LitElement {
     }
     config.money_decimals = config.money_decimals ? config.money_decimals : 2;
     config.money_unit = config.money_unit ? config.money_unit : '€';
-    config.color_icons = config.color_icons ? (config.color_icons == true) : false;
+    config.color_icons = config.color_icons !== false;
     config.consuming_color = config.color_icons
       ? (config.consuming_color ? config.consuming_color : 'var(--label-badge-yellow, #f4b400)')
       : 'var(--state-icon-unavailable-color, #bdbdbd)';

--- a/power-wheel-card/power-wheel-card.js
+++ b/power-wheel-card/power-wheel-card.js
@@ -148,10 +148,11 @@ class PowerWheelCard extends LitElement {
     }
   }
 
-  _makeArrowObject(val, entity, icon, decimals) {
-    const valueStr = typeof val === 'undefined' ? 'unavailable' : val.toFixed(decimals);
+  _makeArrowObject(val, entity, iconNormal, iconReversed, decimals) {
+    const valueStr = typeof val === 'undefined' ? 'unavailable' : Math.abs(val).toFixed(decimals);
     const stateObj = entity ? this.hass.states[entity] : false;
-    const classValue = typeof val !== 'undefined' && val > 0 ? 'active' : 'inactive';
+    const classValue = typeof val !== 'undefined' && val === 0 ? 'inactive' : 'active';
+    const icon = typeof val !== 'undefined' && val < 0 ? iconReversed : iconNormal;
 
     return {
       stateObj,
@@ -324,9 +325,9 @@ class PowerWheelCard extends LitElement {
         'mdi:transmission-tower', this.config.money_decimals);
       this.data.home = this._makePositionObject(this.data.home.val, this.config.home_energy_entity, this.config.home_icon,
         'mdi:home', this.config.money_decimals);
-      this.data.solar2grid = this._makeArrowObject(this.data.solar2grid.val, false, 'mdi:arrow-bottom-left', this.config.money_decimals);
-      this.data.solar2home = this._makeArrowObject(this.data.solar2home.val, false, 'mdi:arrow-bottom-right', this.config.money_decimals);
-      this.data.grid2home = this._makeArrowObject(this.data.grid2home.val, false, 'mdi:arrow-right', this.config.money_decimals);
+      this.data.solar2grid = this._makeArrowObject(this.data.solar2grid.val, false, 'mdi:arrow-bottom-left', 'mdi:arrow-top-right', this.config.money_decimals);
+      this.data.solar2home = this._makeArrowObject(this.data.solar2home.val, false, 'mdi:arrow-bottom-right', 'mdi:arrow-top-left', this.config.money_decimals);
+      this.data.grid2home = this._makeArrowObject(this.data.grid2home.val, false, 'mdi:arrow-right', 'mdi:arrow-left', this.config.money_decimals);
     } else if (this.view === 'energy' && this.energy_capable) {
       this.data.solar.val = this._calculateSolarValue(this.config.solar_energy_entity);
       this.data.grid2home.val = this._calculateGrid2HomeValue(this.config.grid_energy_consumption_entity);
@@ -340,9 +341,9 @@ class PowerWheelCard extends LitElement {
           'mdi:transmission-tower', this.config.energy_decimals);
       this.data.home = this._makePositionObject(this.data.home.val, this.config.home_energy_entity, this.config.home_icon,
           'mdi:home', this.config.energy_decimals);
-      this.data.solar2grid = this._makeArrowObject(this.data.solar2grid.val, this.config.grid_energy_production_entity, 'mdi:arrow-bottom-left', this.config.energy_decimals);
-      this.data.solar2home = this._makeArrowObject(this.data.solar2home.val, false, 'mdi:arrow-bottom-right', this.config.energy_decimals);
-      this.data.grid2home = this._makeArrowObject(this.data.grid2home.val, this.config.grid_energy_consumption_entity, 'mdi:arrow-right', this.config.energy_decimals);
+      this.data.solar2grid = this._makeArrowObject(this.data.solar2grid.val, this.config.grid_energy_production_entity, 'mdi:arrow-bottom-left', 'mdi:arrow-top-right', this.config.energy_decimals);
+      this.data.solar2home = this._makeArrowObject(this.data.solar2home.val, false, 'mdi:arrow-bottom-right', 'mdi:arrow-top-left', this.config.energy_decimals);
+      this.data.grid2home = this._makeArrowObject(this.data.grid2home.val, this.config.grid_energy_consumption_entity, 'mdi:arrow-right', 'mdi:arrow-left', this.config.energy_decimals);
     } else {
       this.data.solar.val = this._calculateSolarValue(this.config.solar_power_entity);
       this.data.grid2home.val = this._calculateGrid2HomeValue(this.config.grid_power_consumption_entity);
@@ -356,9 +357,9 @@ class PowerWheelCard extends LitElement {
           'mdi:transmission-tower', this.config.power_decimals);
       this.data.home = this._makePositionObject(this.data.home.val, this.config.home_power_entity, this.config.home_icon,
           'mdi:home', this.config.power_decimals);
-      this.data.solar2grid = this._makeArrowObject(this.data.solar2grid.val, this.config.grid_power_production_entity, 'mdi:arrow-bottom-left', this.config.power_decimals);
-      this.data.solar2home = this._makeArrowObject(this.data.solar2home.val, false, 'mdi:arrow-bottom-right', this.config.power_decimals);
-      this.data.grid2home = this._makeArrowObject(this.data.grid2home.val, this.config.grid_power_consumption_entity, 'mdi:arrow-right', this.config.power_decimals);
+      this.data.solar2grid = this._makeArrowObject(this.data.solar2grid.val, this.config.grid_power_production_entity, 'mdi:arrow-bottom-left', 'mdi:arrow-top-right', this.config.power_decimals);
+      this.data.solar2home = this._makeArrowObject(this.data.solar2home.val, false, 'mdi:arrow-bottom-right', 'mdi:arrow-top-left', this.config.power_decimals);
+      this.data.grid2home = this._makeArrowObject(this.data.grid2home.val, this.config.grid_power_consumption_entity, 'mdi:arrow-right', 'mdi:arrow-left', this.config.power_decimals);
     }
 
     if (this.autoToggleView) {

--- a/power-wheel-card/power-wheel-card.js
+++ b/power-wheel-card/power-wheel-card.js
@@ -5,7 +5,7 @@
  *
  */
 
-const __VERSION = "0.0.10";
+const __VERSION = "0.0.11-dev";
 
 const LitElement = Object.getPrototypeOf(customElements.get("home-assistant-main"));
 const html = LitElement.prototype.html;
@@ -280,6 +280,7 @@ class PowerWheelCard extends LitElement {
   firstUpdated() {
     if (this.config.debug) {
       let line = `Version: ${__VERSION}\nLovelace resource: ${this._lovelaceResource()}\nHA version: ${this.hass.config.version}`;
+      line += `\nAgent: ${navigator.userAgent}`;
       line += `\nReport issues here: https://github.com/gurbyz/custom-cards-lovelace/issues`;
       line += `\nProcessed config: ${JSON.stringify(this.config, '', ' ')}\nRegistered sensors: ${JSON.stringify(this.sensors, '', ' ')}`;
       this._logConsole(line);

--- a/power-wheel-card/power-wheel-card.js
+++ b/power-wheel-card/power-wheel-card.js
@@ -173,7 +173,7 @@ class PowerWheelCard extends LitElement {
     } else if(this.view === 'power') {
       const gridStateObj = this.hass.states[grid_entity];
       const value = gridStateObj
-        ? parseFloat(gridStateObj.state) * this.config.grid_power_production_is_positive : undefined;
+        ? parseFloat(gridStateObj.state) * this.config.production_is_positive : undefined;
       return value < 0 ? Math.abs(value) : 0;
     } else {
       return 0;
@@ -187,7 +187,7 @@ class PowerWheelCard extends LitElement {
     } else if(this.view === 'power') {
       const gridStateObj = this.hass.states[grid_entity];
       const value = gridStateObj
-        ? parseFloat(gridStateObj.state) * this.config.grid_power_production_is_positive : undefined;
+        ? parseFloat(gridStateObj.state) * this.config.production_is_positive : undefined;
       return value > 0 ? value : 0;
     } else {
       return 0;
@@ -201,17 +201,17 @@ class PowerWheelCard extends LitElement {
     } else {
       const gridStateObj = this.hass.states[grid_entity];
       return gridStateObj
-        ? parseFloat(gridStateObj.state) * this.config.grid_power_production_is_positive : undefined;
+        ? parseFloat(gridStateObj.state) * this.config.production_is_positive : undefined;
     }
   }
 
-  _calculateHomeValue() {
+  _calculateHomeValue(home_entity) {
     if (this.views[this.view].twoGridSensors || this.view === 'power') {
       return typeof this.data.solar.val !== 'undefined' && typeof this.data.grid.val !== 'undefined'
         ? this.data.grid.val - this.data.solar.val : undefined;
     } else {
-      // todo: get home value from separate sensor?
-      return 0;
+      const homeStateObj = this.hass.states[home_entity];
+      return homeStateObj ? parseFloat(homeStateObj.state) * this.config.production_is_positive : undefined;
     }
   }
 
@@ -358,7 +358,7 @@ class PowerWheelCard extends LitElement {
       this.data.grid2home.val = this.config.energy_price * this._calculateGrid2HomeValue(this.config.grid_energy_consumption_entity, this.config.grid_energy_entity);
       this.data.solar2grid.val = this.config.energy_price * this._calculateSolar2GridValue(this.config.grid_energy_production_entity, this.config.grid_energy_entity);
       this.data.grid.val = this._calculateGridValue(this.config.grid_energy_entity);
-      this.data.home.val = this._calculateHomeValue();
+      this.data.home.val = this._calculateHomeValue(this.config.home_energy_entity);
       this.data.solar2home.val = this._calculateSolar2HomeValue();
       this.data.solar = this._makePositionObject(this.data.solar.val, this.config.solar_energy_entity, this.config.solar_icon,
         'mdi:weather-sunny', this.config.money_decimals);
@@ -374,7 +374,7 @@ class PowerWheelCard extends LitElement {
       this.data.grid2home.val = this._calculateGrid2HomeValue(this.config.grid_energy_consumption_entity, this.config.grid_energy_entity);
       this.data.solar2grid.val = this._calculateSolar2GridValue(this.config.grid_energy_production_entity, this.config.grid_energy_entity);
       this.data.grid.val = this._calculateGridValue(this.config.grid_energy_entity);
-      this.data.home.val = this._calculateHomeValue();
+      this.data.home.val = this._calculateHomeValue(this.config.home_energy_entity);
       this.data.solar2home.val = this._calculateSolar2HomeValue();
       this.data.solar = this._makePositionObject(this.data.solar.val, this.config.solar_energy_entity, this.config.solar_icon,
           'mdi:weather-sunny', this.config.energy_decimals);
@@ -538,8 +538,8 @@ class PowerWheelCard extends LitElement {
     if (config.grid_power_consumption_entity && !config.grid_power_production_entity) {
       throw new Error('You need to define a grid_power_production_entity');
     }
-    config.grid_power_production_is_positive = config.grid_power_production_is_positive !== false;
-    config.grid_power_production_is_positive = config.grid_power_production_is_positive ? 1 : -1;
+    config.production_is_positive = config.production_is_positive !== false;
+    config.production_is_positive = config.production_is_positive ? 1 : -1;
     config.title = config.title ? config.title : 'Power wheel';
     config.title_power = config.title_power ? config.title_power : config.title;
     config.title_energy = config.title_energy ? config.title_energy : config.title;
@@ -583,7 +583,7 @@ class PowerWheelCard extends LitElement {
     this.views.power.capable = (this.views.power.oneGridSensor || this.views.power.twoGridSensors) && !!config.solar_power_entity;
     this.views.energy = {
       title: config.title_energy,
-      oneGridSensor: !!config.grid_energy_entity,
+      oneGridSensor: !!config.grid_energy_entity && !!config.home_energy_entity,
       twoGridSensors: !!config.grid_energy_consumption_entity && !!config.grid_energy_production_entity,
     };
     this.views.energy.capable = (this.views.energy.oneGridSensor || this.views.energy.twoGridSensors) && !!config.solar_energy_entity;

--- a/power-wheel-card/power-wheel-card.js
+++ b/power-wheel-card/power-wheel-card.js
@@ -194,9 +194,9 @@ class PowerWheelCard extends LitElement {
   }
 
   _logConsole(message) {
-    if (this.config.debug) {
+    // if (this.config.debug) {
       console.info(`%cpower-wheel-card%c\n${message}`, "color: green; font-weight: bold", "");
-    }
+    // }
   }
 
   /* Lit functions */
@@ -453,9 +453,9 @@ class PowerWheelCard extends LitElement {
           this.view = 'power';
         }
         break;
-      case 'money':
-        this.view = 'power';
-        break;
+      // case 'money':
+      //   this.view = 'power';
+      //   break;
       default:
         this.view = 'power';
     }

--- a/power-wheel-card/test/auto_toggle.html
+++ b/power-wheel-card/test/auto_toggle.html
@@ -90,7 +90,6 @@
     });
 
     test('can automatically toggle from power view to energy view', (done) => {
-
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'W', 'Card should be in power view');
         setTimeout(() => {
@@ -101,7 +100,6 @@
     });
 
     test('can switch off auto toggling with toggle button', (done) => {
-
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'W', 'Card should be in power view');
         card.shadowRoot.querySelector('#toggle-button').click();
@@ -113,7 +111,6 @@
     });
 
     test('can switch off auto toggling with click on unit', (done) => {
-
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'W', 'Card should be in power view');
         card.shadowRoot.querySelector('#unit').click();

--- a/power-wheel-card/test/auto_toggle.html
+++ b/power-wheel-card/test/auto_toggle.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../bower_components/webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="../../bower_components/web-component-tester/browser.js"></script>
+  <script type="module" src="../../test/home-assistant-main-mock.js"></script>
+  <script type="module" src="../power-wheel-card.js"></script>
+</head>
+<body>
+<test-fixture id="simple">
+  <template>
+    <power-wheel-card></power-wheel-card>
+  </template>
+</test-fixture>
+<script>
+  suite('<power-wheel-card> with automatic toggling between views', () => {
+    let card, hass, config;
+
+    setup(() => {
+      card = fixture('simple');
+      config = {
+        type: "custom:power-wheel-card",
+        solar_power_entity: "sensor.solar_power",
+        grid_power_consumption_entity: "sensor.grid_power_consumption",
+        grid_power_production_entity: "sensor.grid_power_production",
+        solar_energy_entity: "sensor.solar_energy",
+        grid_energy_consumption_entity: "sensor.grid_energy_consumption",
+        grid_energy_production_entity: "sensor.grid_energy_production",
+        energy_price: 1.00,
+        initial_auto_toggle_view: true,
+        auto_toggle_view_period: 1,
+      };
+      hass = {
+        states: {
+          "sensor.solar_power" : {
+            attributes: {
+              unit_of_measurement: "W",
+            },
+            entity_id: "sensor.solar_power",
+            state: "500",
+          },
+          "sensor.grid_power_consumption" : {
+            attributes: {
+              unit_of_measurement: "W",
+            },
+            entity_id: "sensor.grid_power_consumption",
+            state: "1800",
+          },
+          "sensor.grid_power_production" : {
+            attributes: {
+              unit_of_measurement: "W",
+            },
+            entity_id: "sensor.grid_power_production",
+            state: "0",
+          },
+          "sensor.solar_energy" : {
+            attributes: {
+              unit_of_measurement: "kWh",
+            },
+            entity_id: "sensor.solar_energy",
+            state: "5",
+          },
+          "sensor.grid_energy_consumption" : {
+            attributes: {
+              unit_of_measurement: "kWh",
+            },
+            entity_id: "sensor.grid_energy_consumption",
+            state: "18",
+          },
+          "sensor.grid_energy_production" : {
+            attributes: {
+              unit_of_measurement: "kWh",
+            },
+            entity_id: "sensor.grid_energy_production",
+            state: "0",
+          },
+        },
+      };
+      card.setAttribute('hass', JSON.stringify(hass));
+      card.setConfig(config);
+    });
+
+    test('has set config values', (done) => {
+      flush(() => {
+        assert.isTrue(card.config.initial_auto_toggle_view, 'Card parameter initial_auto_toggle_view should be set');
+        assert.equal(card.config.auto_toggle_view_period, 1, 'Card parameter auto_toggle_view_period should be set');
+        done();
+      });
+    });
+
+    test('can automatically toggle from power view to energy view', (done) => {
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'W', 'Card should be in power view');
+        setTimeout(() => {
+          assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'kWh', 'Card should be in energy view');
+          done();
+        }, 1050);
+      })
+    });
+
+    test('can switch off auto toggling with toggle button', (done) => {
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'W', 'Card should be in power view');
+        card.shadowRoot.querySelector('#toggle-button').click();
+        setTimeout(() => {
+          assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'W', 'Card should be still in power view');
+          done();
+        }, 1050);
+      })
+    });
+
+    test('can switch off auto toggling with click on unit', (done) => {
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'W', 'Card should be in power view');
+        card.shadowRoot.querySelector('#unit').click();
+        flush(() => {
+          assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'kWh', 'Card should go to energy view first');
+          setTimeout(() => {
+            assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'kWh', 'Card should be still in energy view');
+            done();
+          }, 1050);
+        });
+      })
+    });
+
+  });
+</script>
+</body>
+</html>

--- a/power-wheel-card/test/basic_config.html
+++ b/power-wheel-card/test/basic_config.html
@@ -26,6 +26,7 @@
         solar_power_entity: "sensor.solar_power",
         grid_power_consumption_entity: "sensor.grid_power_consumption",
         grid_power_production_entity: "sensor.grid_power_production",
+        color_icons: false,
       };
       hass = {
         states: {
@@ -79,7 +80,7 @@
 
     test('has set default config values', (done) => {
       flush(() => {
-        assert.isFalse(card.config.color_icons, 'Card parameter color_icons should be default false');
+        assert.isFalse(card.config.color_icons, 'Card parameter color_icons should be set');
         assert.isFalse(card.config.debug, 'Card parameter debug should be default false');
         assert.equal(card.config.title, 'Power wheel', 'Card parameter title should have default value');
         assert.equal(card.config.title_power, 'Power wheel', 'Card parameter title_power should have default value');
@@ -156,8 +157,8 @@
     test('displays values when consuming from the grid', (done) => {
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '500', 'Solar should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '1800', 'Grid should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '2300', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-1800', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-2300', 'Home should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
@@ -182,8 +183,8 @@
 
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '500', 'Solar should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-50', 'Grid should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '450', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '50', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-450', 'Home should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '50', 'Solar2Grid arrow should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '450', 'Solar2Home arrow should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
@@ -234,14 +235,15 @@
     });
 
     test('displays values when solar inverter consumes power', (done) => {
+      // todo: Negative solar power isn't handled well. E.g. Solar2Grid should have -5 instead of Solar2Home.
       setCardSolarConsuming();
 
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '-5', 'Solar should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '5', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-5', 'Grid should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '0', 'Home should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
-        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '-5', 'Solar2Home arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
         done();
       });

--- a/power-wheel-card/test/basic_config.html
+++ b/power-wheel-card/test/basic_config.html
@@ -81,7 +81,7 @@
     test('has set default config values', (done) => {
       flush(() => {
         assert.isFalse(card.config.color_icons, 'Card parameter color_icons should be set');
-        assert.equal(card.config.grid_power_production_is_positive, 1, 'Card parameter grid_power_production_is_positive should be default 1');
+        assert.equal(card.config.production_is_positive, 1, 'Card parameter production_is_positive should be default 1');
         assert.isFalse(card.config.debug, 'Card parameter debug should be default false');
         assert.equal(card.config.title, 'Power wheel', 'Card parameter title should have default value');
         assert.equal(card.config.title_power, 'Power wheel', 'Card parameter title_power should have default value');

--- a/power-wheel-card/test/basic_config.html
+++ b/power-wheel-card/test/basic_config.html
@@ -144,6 +144,9 @@
         assert.equal(card.shadowRoot.querySelector('#icon-solar').getAttribute('icon'), 'mdi:weather-sunny', 'Solar icon should be default icon');
         assert.equal(card.shadowRoot.querySelector('#icon-grid').getAttribute('icon'), 'mdi:transmission-tower', 'Grid icon should be default icon');
         assert.equal(card.shadowRoot.querySelector('#icon-home').getAttribute('icon'), 'mdi:home', 'Home icon should be default icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
         assert.equal(card.shadowRoot.querySelector('#cell-solar').getAttribute('title'), 'More info:\nSolar Power', 'Solar title should be set');
         assert.equal(card.shadowRoot.querySelector('#cell-grid').getAttribute('title'), '', 'Grid title should be set');
         assert.equal(card.shadowRoot.querySelector('#cell-home').getAttribute('title'), '', 'Home title should be set');
@@ -171,6 +174,9 @@
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('producing'), 'Solar icon should be producing');
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('consuming'), 'Grid icon should be consuming');
         assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('inactive'), 'Solar2Grid arrow icon should be inactive');
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('active'), 'Solar2Home arrow icon should be active');
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('active'), 'Grid2Home arrow icon should be active');
@@ -199,6 +205,9 @@
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('producing'), 'Solar icon should be producing');
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('producing'), 'Grid icon should be producing');
         assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('active'), 'Solar2Grid arrow icon should be active');
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('active'), 'Solar2Home arrow icon should be active');
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('inactive'), 'Grid2Home arrow icon should be inactive');
@@ -227,6 +236,9 @@
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('inactive'), 'Solar icon should be inactive');
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('inactive'), 'Grid icon should be inactive');
         assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('inactive'), 'Home icon should be inactive');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('inactive'), 'Solar2Grid arrow icon should be inactive');
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('inactive'), 'Solar2Home arrow icon should be inactive');
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('inactive'), 'Grid2Home arrow icon should be inactive');
@@ -235,7 +247,6 @@
     });
 
     test('displays values when solar inverter consumes power', (done) => {
-      // todo: Negative solar power isn't handled well. E.g. Solar2Grid should have -5 instead of Solar2Home.
       setCardSolarConsuming();
 
       flush(() => {
@@ -243,22 +254,24 @@
         assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-5', 'Grid should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '0', 'Home should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
-        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '-5', 'Solar2Home arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '5', 'Solar2Home arrow should have a value');
         assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
         done();
       });
     });
 
     test('has ui elements when solar inverter consumes power', (done) => {
-      // todo: Negative solar power isn't handled well. E.g. Grid2Home should be inactive.
       setCardSolarConsuming();
 
       flush(() => {
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('consuming'), 'Solar icon should be inactive');
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('consuming'), 'Grid icon should be inactive');
         assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('inactive'), 'Home icon should be inactive');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-top-left', 'Solar2Home icon should be reversed icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('inactive'), 'Solar2Grid arrow icon should be inactive');
-        assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('inactive'), 'Solar2Home arrow icon should be inactive');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('active'), 'Solar2Home arrow icon should be inactive');
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('active'), 'Grid2Home arrow icon should be active');
         done();
       });

--- a/power-wheel-card/test/basic_config.html
+++ b/power-wheel-card/test/basic_config.html
@@ -81,6 +81,7 @@
     test('has set default config values', (done) => {
       flush(() => {
         assert.isFalse(card.config.color_icons, 'Card parameter color_icons should be set');
+        assert.equal(card.config.grid_power_production_is_positive, 1, 'Card parameter grid_power_production_is_positive should be default 1');
         assert.isFalse(card.config.debug, 'Card parameter debug should be default false');
         assert.equal(card.config.title, 'Power wheel', 'Card parameter title should have default value');
         assert.equal(card.config.title_power, 'Power wheel', 'Card parameter title_power should have default value');

--- a/power-wheel-card/test/basic_config.html
+++ b/power-wheel-card/test/basic_config.html
@@ -32,6 +32,7 @@
           "sensor.solar_power" : {
             attributes: {
               unit_of_measurement: "W",
+              friendly_name: "Solar Power",
             },
             entity_id: "sensor.solar_power",
             state: "500.1",
@@ -59,6 +60,20 @@
     const setCardProducingToGrid = () => {
       hass.states['sensor.grid_power_consumption'].state = "0";
       hass.states['sensor.grid_power_production'].state = "50";
+      card.setAttribute('hass', JSON.stringify(hass));
+    };
+
+    const setCardAllInactive = () => {
+      hass.states['sensor.solar_power'].state = "0";
+      hass.states['sensor.grid_power_consumption'].state = "0";
+      hass.states['sensor.grid_power_production'].state = "0";
+      card.setAttribute('hass', JSON.stringify(hass));
+    };
+
+    const setCardSolarConsuming = () => {
+      hass.states['sensor.solar_power'].state = "-5";
+      hass.states['sensor.grid_power_consumption'].state = "5";
+      hass.states['sensor.grid_power_production'].state = "0";
       card.setAttribute('hass', JSON.stringify(hass));
     };
 
@@ -128,6 +143,12 @@
         assert.equal(card.shadowRoot.querySelector('#icon-solar').getAttribute('icon'), 'mdi:weather-sunny', 'Solar icon should be default icon');
         assert.equal(card.shadowRoot.querySelector('#icon-grid').getAttribute('icon'), 'mdi:transmission-tower', 'Grid icon should be default icon');
         assert.equal(card.shadowRoot.querySelector('#icon-home').getAttribute('icon'), 'mdi:home', 'Home icon should be default icon');
+        assert.equal(card.shadowRoot.querySelector('#cell-solar').getAttribute('title'), 'More info:\nSolar Power', 'Solar title should be set');
+        assert.equal(card.shadowRoot.querySelector('#cell-grid').getAttribute('title'), '', 'Grid title should be set');
+        assert.equal(card.shadowRoot.querySelector('#cell-home').getAttribute('title'), '', 'Home title should be set');
+        assert.equal(card.shadowRoot.querySelector('#cell-solar2grid').getAttribute('title'), 'More info', 'Solar2Grid title should be set');
+        assert.equal(card.shadowRoot.querySelector('#cell-solar2home').getAttribute('title'), '', 'Solar2Home title should be set');
+        assert.equal(card.shadowRoot.querySelector('#cell-grid2home').getAttribute('title'), 'More info', 'Grid2Home title should be set');
         done();
       });
     });
@@ -182,6 +203,80 @@
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('inactive'), 'Grid2Home arrow icon should be inactive');
         done();
       });
+    });
+
+    test('displays values when all sensor values are zero', (done) => {
+      setCardAllInactive();
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '0', 'Solar should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '0', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '0', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+        done();
+      });
+    });
+
+    test('has ui elements when all sensor values are zero', (done) => {
+      setCardAllInactive();
+
+      flush(() => {
+        assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('inactive'), 'Solar icon should be inactive');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('inactive'), 'Grid icon should be inactive');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('inactive'), 'Home icon should be inactive');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('inactive'), 'Solar2Grid arrow icon should be inactive');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('inactive'), 'Solar2Home arrow icon should be inactive');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('inactive'), 'Grid2Home arrow icon should be inactive');
+        done();
+      });
+    });
+
+    test('displays values when solar inverter consumes power', (done) => {
+      setCardSolarConsuming();
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '-5', 'Solar should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '5', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '0', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+        done();
+      });
+    });
+
+    test('has ui elements when solar inverter consumes power', (done) => {
+      // todo: Negative solar power isn't handled well. E.g. Grid2Home should be inactive.
+      setCardSolarConsuming();
+
+      flush(() => {
+        assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('consuming'), 'Solar icon should be inactive');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('consuming'), 'Grid icon should be inactive');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('inactive'), 'Home icon should be inactive');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('inactive'), 'Solar2Grid arrow icon should be inactive');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('inactive'), 'Solar2Home arrow icon should be inactive');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('active'), 'Grid2Home arrow icon should be active');
+        done();
+      });
+    });
+
+    test('updates when sensor value changes', (done) => {
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '500', 'Solar should have value set');
+        hass.states['sensor.solar_power'].state = "501";
+        card.setAttribute('hass', JSON.stringify(hass));
+
+        flush(() => {
+          assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '501', 'Solar should have changed value');
+          done();
+        });
+      });
+    });
+
+    test('has card size', () => {
+      assert.equal(card.getCardSize(), 5, 'getCardSize should respond');
     });
 
   });

--- a/power-wheel-card/test/basic_one_grid_sensor.html
+++ b/power-wheel-card/test/basic_one_grid_sensor.html
@@ -14,18 +14,15 @@
   </template>
 </test-fixture>
 <script>
-  suite('<power-wheel-card> with most basic config', () => {
+  suite('<power-wheel-card> with most basic config for one grid sensor', () => {
     let card, hass, config;
-
-    /** Tests are extended in energy_capable. **/
 
     setup(() => {
       card = fixture('simple');
       config = {
         type: "custom:power-wheel-card",
         solar_power_entity: "sensor.solar_power",
-        grid_power_consumption_entity: "sensor.grid_power_consumption",
-        grid_power_production_entity: "sensor.grid_power_production",
+        grid_power_entity: "sensor.grid_power",
         color_icons: false,
       };
       hass = {
@@ -38,19 +35,12 @@
             entity_id: "sensor.solar_power",
             state: "500.1",
           },
-          "sensor.grid_power_consumption" : {
+          "sensor.grid_power" : {
             attributes: {
               unit_of_measurement: "W",
             },
-            entity_id: "sensor.grid_power_consumption",
-            state: "1799.9",
-          },
-          "sensor.grid_power_production" : {
-            attributes: {
-              unit_of_measurement: "W",
-            },
-            entity_id: "sensor.grid_power_production",
-            state: "0",
+            entity_id: "sensor.grid_power",
+            state: "-1799.9",
           },
         },
       };
@@ -59,58 +49,26 @@
     });
 
     const setCardProducingToGrid = () => {
-      hass.states['sensor.grid_power_consumption'].state = "0";
-      hass.states['sensor.grid_power_production'].state = "50";
+      hass.states['sensor.grid_power'].state = "50";
       card.setAttribute('hass', JSON.stringify(hass));
     };
 
     const setCardAllInactive = () => {
       hass.states['sensor.solar_power'].state = "0";
-      hass.states['sensor.grid_power_consumption'].state = "0";
-      hass.states['sensor.grid_power_production'].state = "0";
+      hass.states['sensor.grid_power'].state = "0";
       card.setAttribute('hass', JSON.stringify(hass));
     };
 
     const setCardSolarConsuming = () => {
       hass.states['sensor.solar_power'].state = "-5";
-      hass.states['sensor.grid_power_consumption'].state = "5";
-      hass.states['sensor.grid_power_production'].state = "0";
+      hass.states['sensor.grid_power'].state = "-5";
       card.setAttribute('hass', JSON.stringify(hass));
     };
 
-    test('has set default config values', (done) => {
-      flush(() => {
-        assert.isFalse(card.config.color_icons, 'Card parameter color_icons should be set');
-        assert.isFalse(card.config.debug, 'Card parameter debug should be default false');
-        assert.equal(card.config.title, 'Power wheel', 'Card parameter title should have default value');
-        assert.equal(card.config.title_power, 'Power wheel', 'Card parameter title_power should have default value');
-        assert.equal(card.config.title_energy, 'Power wheel', 'Card parameter title_energy should have default value');
-        assert.equal(card.config.title_money, 'Power wheel', 'Card parameter title_money should have default value');
-        assert.equal(card.config.power_decimals, 0, 'Card parameter power_decimals should have default value');
-        assert.equal(card.config.energy_decimals, 3, 'Card parameter energy_decimals should have default value');
-        assert.equal(card.config.money_decimals, 2, 'Card parameter money_decimals should have default value');
-        assert.equal(card.config.money_unit, '€', 'Card parameter money_unit should have default value');
-        assert.equal(card.config.consuming_color, 'var(--state-icon-unavailable-color, #bdbdbd)', 'Card parameter consuming_color should have default value');
-        assert.equal(card.config.producing_color, 'var(--state-icon-unavailable-color, #bdbdbd)', 'Card parameter producing_color should have default value');
-        assert.equal(card.config.initial_view, 'power', 'Card parameter initial_view should have default value');
-        assert.isFalse(card.config.initial_auto_toggle_view, 'Card parameter initial_auto_toggle_view should be default false');
-        assert.equal(card.config.auto_toggle_view_period, 10, 'Card parameter auto_toggle_view_period should have default value');
-        done();
-      });
-    });
-
     test('has set card property values after setConfig', (done) => {
       flush(() => {
-        assert.isFalse(card.autoToggleView, 'Card property autoToggleView should be default false');
-        assert.deepEqual(card.sensors, [ "sensor.solar_power", "sensor.grid_power_consumption", "sensor.grid_power_production" ], 'Card property sensors should have default value');
-        assert.equal(card.view, 'power', 'Card property view should have default value');
-        assert.equal(card.views.power.title, 'Power wheel', 'Card property views should have default value for power view title');
-        assert.equal(card.views.energy.title, 'Power wheel', 'Card property views should have default value for energy view title');
-        assert.equal(card.views.money.title, 'Power wheel', 'Card property views should have default value for money view title');
-        assert.isFalse(card.views.energy.capable, 'Card property views should have default value for energy capable');
-        assert.isFalse(card.views.money.capable, 'Card property views should have default value for money capable');
-        assert.isFalse(card.views.power.oneGridSensor, 'Card property views should have value set for power oneGridSensor');
-        assert.isTrue(card.views.power.twoGridSensors, 'Card property views should have value set for power twoGridSensors');
+        assert.isTrue(card.views.power.oneGridSensor, 'Card property views should have value set for power oneGridSensor');
+        assert.isFalse(card.views.power.twoGridSensors, 'Card property views should have value set for power twoGridSensors');
         done();
       });
     });
@@ -118,17 +76,6 @@
     test('has no warnings or errors', (done) => {
       flush(() => {
         assert.equal(card.shadowRoot.querySelectorAll('.message').length, 0, 'Number of messages should be zero');
-        done();
-      });
-    });
-
-    test('uses color values', (done) => {
-      // After testing this, the other tests can just check for class values 'inactive', 'consuming' and 'producing'.
-      flush(() => {
-        assert.equal(window.getComputedStyle(card.shadowRoot.querySelector('ha-icon.consuming'), null).getPropertyValue('color'), 'rgb(189, 189, 189)', 'Consuming icon color should be #bdbdbd');
-        assert.equal(window.getComputedStyle(card.shadowRoot.querySelector('ha-icon.producing'), null).getPropertyValue('color'), 'rgb(189, 189, 189)', 'Producing icon color should be #bdbdbd');
-        assert.equal(window.getComputedStyle(card.shadowRoot.querySelector('ha-icon.active'), null).getPropertyValue('color'), 'rgb(253, 216, 53)', 'Active arrow icon color should be #fdd835');
-        assert.equal(window.getComputedStyle(card.shadowRoot.querySelector('ha-icon.inactive'), null).getPropertyValue('color'), 'rgb(189, 189, 189)', 'Inactive arrow icon color should be #bdbdbd');
         done();
       });
     });
@@ -143,20 +90,9 @@
 
     test('has ui elements', (done) => {
       flush(() => {
-        assert.equal(card.shadowRoot.querySelectorAll('#toggle-button').length, 0, 'Toggle button shouldn\'t be there');
-        assert.isFalse(card.shadowRoot.querySelector('#unit').classList.contains('toggle'), 'Unit shouldn\'t be toggleable');
-        assert.equal(card.shadowRoot.querySelector('#icon-solar').getAttribute('icon'), 'mdi:weather-sunny', 'Solar icon should be default icon');
-        assert.equal(card.shadowRoot.querySelector('#icon-grid').getAttribute('icon'), 'mdi:transmission-tower', 'Grid icon should be default icon');
-        assert.equal(card.shadowRoot.querySelector('#icon-home').getAttribute('icon'), 'mdi:home', 'Home icon should be default icon');
         assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
         assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
         assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
-        assert.equal(card.shadowRoot.querySelector('#cell-solar').getAttribute('title'), 'More info:\nSolar Power', 'Solar title should be set');
-        assert.equal(card.shadowRoot.querySelector('#cell-grid').getAttribute('title'), '', 'Grid title should be set');
-        assert.equal(card.shadowRoot.querySelector('#cell-home').getAttribute('title'), '', 'Home title should be set');
-        assert.equal(card.shadowRoot.querySelector('#cell-solar2grid').getAttribute('title'), 'More info', 'Solar2Grid title should be set');
-        assert.equal(card.shadowRoot.querySelector('#cell-solar2home').getAttribute('title'), '', 'Solar2Home title should be set');
-        assert.equal(card.shadowRoot.querySelector('#cell-grid2home').getAttribute('title'), 'More info', 'Grid2Home title should be set');
         done();
       });
     });

--- a/power-wheel-card/test/basic_one_grid_sensor.html
+++ b/power-wheel-card/test/basic_one_grid_sensor.html
@@ -25,7 +25,7 @@
         type: "custom:power-wheel-card",
         solar_power_entity: "sensor.solar_power",
         grid_power_entity: "sensor.grid_power",
-        grid_power_production_is_positive: true,
+        production_is_positive: true,
         color_icons: false,
       };
       hass = {
@@ -70,7 +70,7 @@
 
     test('has set config values', (done) => {
       flush(() => {
-        assert.equal(card.config.grid_power_production_is_positive, 1, 'Card parameter grid_power_production_is_positive should be default 1');
+        assert.equal(card.config.production_is_positive, 1, 'Card parameter production_is_positive should be default 1');
         done();
       });
     });

--- a/power-wheel-card/test/basic_one_grid_sensor_switched_polarity.html
+++ b/power-wheel-card/test/basic_one_grid_sensor_switched_polarity.html
@@ -14,10 +14,10 @@
   </template>
 </test-fixture>
 <script>
-  suite('<power-wheel-card> with most basic config for one grid sensor', () => {
+  suite('<power-wheel-card> with most basic config for one grid sensor with switched polarity', () => {
     let card, hass, config;
 
-    /** Tests are also used in basic_one_grid_sensor_switched_polarity.html **/
+    /** Tests are also used in basic_one_grid_sensor.html **/
 
     setup(() => {
       card = fixture('simple');
@@ -25,7 +25,7 @@
         type: "custom:power-wheel-card",
         solar_power_entity: "sensor.solar_power",
         grid_power_entity: "sensor.grid_power",
-        grid_power_production_is_positive: true,
+        grid_power_production_is_positive: false,
         color_icons: false,
       };
       hass = {
@@ -43,7 +43,7 @@
               unit_of_measurement: "W",
             },
             entity_id: "sensor.grid_power",
-            state: "-1799.9",
+            state: "1799.9",
           },
         },
       };
@@ -52,7 +52,7 @@
     });
 
     const setCardProducingToGrid = () => {
-      hass.states['sensor.grid_power'].state = "50";
+      hass.states['sensor.grid_power'].state = "-50";
       card.setAttribute('hass', JSON.stringify(hass));
     };
 
@@ -64,13 +64,13 @@
 
     const setCardSolarConsuming = () => {
       hass.states['sensor.solar_power'].state = "-5";
-      hass.states['sensor.grid_power'].state = "-5";
+      hass.states['sensor.grid_power'].state = "5";
       card.setAttribute('hass', JSON.stringify(hass));
     };
 
     test('has set config values', (done) => {
       flush(() => {
-        assert.equal(card.config.grid_power_production_is_positive, 1, 'Card parameter grid_power_production_is_positive should be default 1');
+        assert.equal(card.config.grid_power_production_is_positive, -1, 'Card parameter grid_power_production_is_positive should be -1');
         done();
       });
     });

--- a/power-wheel-card/test/basic_one_grid_sensor_switched_polarity.html
+++ b/power-wheel-card/test/basic_one_grid_sensor_switched_polarity.html
@@ -25,7 +25,7 @@
         type: "custom:power-wheel-card",
         solar_power_entity: "sensor.solar_power",
         grid_power_entity: "sensor.grid_power",
-        grid_power_production_is_positive: false,
+        production_is_positive: false,
         color_icons: false,
       };
       hass = {
@@ -70,7 +70,7 @@
 
     test('has set config values', (done) => {
       flush(() => {
-        assert.equal(card.config.grid_power_production_is_positive, -1, 'Card parameter grid_power_production_is_positive should be -1');
+        assert.equal(card.config.production_is_positive, -1, 'Card parameter production_is_positive should be -1');
         done();
       });
     });

--- a/power-wheel-card/test/color_icons.html
+++ b/power-wheel-card/test/color_icons.html
@@ -168,6 +168,9 @@
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('producing'), 'Solar icon should be producing');
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('producing'), 'Grid icon should be producing');
         assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('active'), 'Solar2Grid arrow icon should be active');
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('active'), 'Solar2Home arrow icon should be active');
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('inactive'), 'Grid2Home arrow icon should be inactive');
@@ -190,7 +193,6 @@
     });
 
     test('displays values in power view when solar inverter consumes power', (done) => {
-      // todo: Negative solar power isn't handled well. E.g. Solar2Grid should have -5 instead of Solar2Home.
       setCardSolarConsuming();
 
       flush(() => {
@@ -198,7 +200,7 @@
         assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '5', 'Grid should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '0', 'Home should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
-        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '-5', 'Solar2Home arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '5', 'Solar2Home arrow should have a value');
         assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
         done();
       });

--- a/power-wheel-card/test/color_icons.html
+++ b/power-wheel-card/test/color_icons.html
@@ -26,7 +26,11 @@
         solar_power_entity: "sensor.solar_power",
         grid_power_consumption_entity: "sensor.grid_power_consumption",
         grid_power_production_entity: "sensor.grid_power_production",
-        color_icons: true,
+        solar_energy_entity: "sensor.solar_energy",
+        grid_energy_consumption_entity: "sensor.grid_energy_consumption",
+        grid_energy_production_entity: "sensor.grid_energy_production",
+        energy_price: 0.20,
+        money_unit: '$',
       };
       hass = {
         states: {
@@ -51,11 +55,68 @@
             entity_id: "sensor.grid_power_production",
             state: "0",
           },
+          "sensor.solar_energy" : {
+            attributes: {
+              unit_of_measurement: "kWh",
+            },
+            entity_id: "sensor.solar_energy",
+            state: "5",
+          },
+          "sensor.grid_energy_consumption" : {
+            attributes: {
+              unit_of_measurement: "kWh",
+            },
+            entity_id: "sensor.grid_energy_consumption",
+            state: "18",
+          },
+          "sensor.grid_energy_production" : {
+            attributes: {
+              unit_of_measurement: "kWh",
+            },
+            entity_id: "sensor.grid_energy_production",
+            state: "0",
+          },
         },
       };
       card.setAttribute('hass', JSON.stringify(hass));
       card.setConfig(config);
     });
+
+    const setCardProducingToGrid = () => {
+      hass.states['sensor.grid_power_consumption'].state = "0";
+      hass.states['sensor.grid_power_production'].state = "50";
+      card.setAttribute('hass', JSON.stringify(hass));
+    };
+
+    const setCardAllInactive = () => {
+      hass.states['sensor.solar_power'].state = "0";
+      hass.states['sensor.grid_power_consumption'].state = "0";
+      hass.states['sensor.grid_power_production'].state = "0";
+      card.setAttribute('hass', JSON.stringify(hass));
+    };
+
+    const setCardSolarConsuming = () => {
+      hass.states['sensor.solar_power'].state = "-5";
+      hass.states['sensor.grid_power_consumption'].state = "5";
+      hass.states['sensor.grid_power_production'].state = "0";
+      card.setAttribute('hass', JSON.stringify(hass));
+    };
+
+    const setCardProducedToGridOnly = () => {
+      hass.states['sensor.grid_energy_consumption'].state = "0";
+      hass.states['sensor.grid_energy_production'].state = "0.5";
+      card.setAttribute('hass', JSON.stringify(hass));
+    };
+
+    const setCardConsumedAndProducedToGrid = () => {
+      hass.states['sensor.grid_energy_consumption'].state = "1";
+      hass.states['sensor.grid_energy_production'].state = "0.5";
+      card.setAttribute('hass', JSON.stringify(hass));
+    };
+
+    const setCardView = (view) => {
+      card.setAttribute('view', view);
+    };
 
     test('has config values', (done) => {
       flush(() => {
@@ -70,6 +131,163 @@
       flush(() => {
         assert.equal(window.getComputedStyle(card.shadowRoot.querySelector('ha-icon.consuming'), null).getPropertyValue('color'), 'rgb(244, 180, 0)', 'Consuming icon color should be #f4b400');
         assert.equal(window.getComputedStyle(card.shadowRoot.querySelector('ha-icon.producing'), null).getPropertyValue('color'), 'rgb(13, 160, 53)', 'Producing icon color should be #0da035');
+        done();
+      });
+    });
+
+    test('displays values in power view when consuming from the grid', (done) => {
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '500', 'Solar should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '1800', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '2300', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+        done();
+      });
+    });
+
+    test('displays values in power view when producing to the grid', (done) => {
+      setCardProducingToGrid();
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '500', 'Solar should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '50', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '450', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '50', 'Solar2Grid arrow should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '450', 'Solar2Home arrow should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+        done();
+      });
+    });
+
+    test('has ui elements in power view when producing to the grid', (done) => {
+      setCardProducingToGrid();
+
+      flush(() => {
+        assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('producing'), 'Solar icon should be producing');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('producing'), 'Grid icon should be producing');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('active'), 'Solar2Grid arrow icon should be active');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('active'), 'Solar2Home arrow icon should be active');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('inactive'), 'Grid2Home arrow icon should be inactive');
+        done();
+      });
+    });
+
+    test('displays values in power view when all sensor values are zero', (done) => {
+      setCardAllInactive();
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '0', 'Solar should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '0', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '0', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+        done();
+      });
+    });
+
+    test('displays values in power view when solar inverter consumes power', (done) => {
+      // todo: Negative solar power isn't handled well. E.g. Solar2Grid should have -5 instead of Solar2Home.
+      setCardSolarConsuming();
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5', 'Solar should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '5', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '0', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '-5', 'Solar2Home arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+        done();
+      });
+    });
+
+    test('displays values in energy view when having consumed from the grid only', (done) => {
+      setCardView('energy');
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5.000', 'Solar should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '18.000', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '23.000', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+        done();
+      });
+    });
+
+    test('displays values in energy view when having produced to the grid only', (done) => {
+      setCardProducedToGridOnly();
+      setCardView('energy');
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5.000', 'Solar should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '0.500', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '4.500', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '0.500', 'Solar2Grid arrow should have a correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '4.500', 'Solar2Home arrow should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+        done();
+      });
+    });
+
+    test('displays values in energy view when having consumed from and produced to the grid', (done) => {
+      setCardConsumedAndProducedToGrid();
+      setCardView('energy');
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5.000', 'Solar should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '0.500', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '5.500', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '0.500', 'Solar2Grid arrow should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '4.500', 'Solar2Home arrow should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '1.000', 'Grid2Home arrow should have correct value');
+        done();
+      });
+    });
+
+    test('displays values in money view when having consumed from the grid only', (done) => {
+      setCardView('money');
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '1.00', 'Solar should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '3.60', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '4.60', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+        done();
+      });
+    });
+
+    test('displays values in money view when having produced to the grid only', (done) => {
+      setCardProducedToGridOnly();
+      setCardView('money');
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '1.00', 'Solar should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '0.10', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '0.90', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '0.10', 'Solar2Grid arrow should have a correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '0.90', 'Solar2Home arrow should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+        done();
+      });
+    });
+
+    test('displays values in money view when having consumed from and produced to the grid', (done) => {
+      setCardConsumedAndProducedToGrid();
+      setCardView('money');
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '1.00', 'Solar should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '0.10', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '1.10', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '0.10', 'Solar2Grid arrow should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '0.90', 'Solar2Home arrow should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '0.20', 'Grid2Home arrow should have correct value');
         done();
       });
     });

--- a/power-wheel-card/test/debug_mode.html
+++ b/power-wheel-card/test/debug_mode.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../bower_components/webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="../../bower_components/web-component-tester/browser.js"></script>
+  <script type="module" src="../../test/home-assistant-main-mock.js"></script>
+  <script type="module" src="../power-wheel-card.js"></script>
+</head>
+<body>
+<test-fixture id="simple">
+  <template>
+    <power-wheel-card></power-wheel-card>
+  </template>
+</test-fixture>
+<script>
+  suite('<power-wheel-card> in debug mode', () => {
+    let card, hass, config;
+
+    setup(() => {
+      card = fixture('simple');
+      config = {
+        type: "custom:power-wheel-card",
+        solar_power_entity: "sensor.solar_power",
+        grid_power_consumption_entity: "sensor.grid_power_consumption",
+        grid_power_production_entity: "sensor.grid_power_production",
+        debug: true,
+      };
+      hass = {
+        config: {
+          version: "1.2.3",
+        },
+        states: {
+          "sensor.solar_power" : {
+            attributes: {
+              unit_of_measurement: "W",
+            },
+            entity_id: "sensor.solar_power",
+            state: "500.1",
+          },
+          "sensor.grid_power_consumption" : {
+            attributes: {
+              unit_of_measurement: "W",
+            },
+            entity_id: "sensor.grid_power_consumption",
+            state: "1799.9",
+          },
+          "sensor.grid_power_production" : {
+            attributes: {
+              unit_of_measurement: "W",
+            },
+            entity_id: "sensor.grid_power_production",
+            state: "0",
+          },
+        },
+      };
+      card.setAttribute('hass', JSON.stringify(hass));
+      card.setConfig(config);
+    });
+
+    test('has set default config values', (done) => {
+      flush(() => {
+        assert.isTrue(card.config.debug, 'Card parameter debug should be set');
+        done();
+      });
+    });
+
+    test('has set card property values after setConfig', (done) => {
+      flush(() => {
+        assert.deepEqual(card.messages, [ { type: 'warn', text: 'Debug mode is on.' } ], 'Card property messages should be set');
+        done();
+      });
+    });
+
+    test('has debug warning', (done) => {
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelectorAll('.message').length, 1, 'There should be a message');
+        done();
+      });
+    });
+
+  });
+</script>
+</body>
+</html>

--- a/power-wheel-card/test/decimals.html
+++ b/power-wheel-card/test/decimals.html
@@ -31,6 +31,7 @@
         energy_decimals: 1,
         money_decimals: 3,
         energy_price: 1.00,
+        color_icons: false,
       };
       hass = {
         states: {
@@ -98,8 +99,8 @@
     test('displays values in power view', (done) => {
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '500.00', 'Solar should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '1800.00', 'Grid should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '2300.00', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-1800.00', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-2300.00', 'Home should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
@@ -112,8 +113,8 @@
 
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5.0', 'Solar should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '18.0', 'Grid should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '23.0', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-18.0', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-23.0', 'Home should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
@@ -126,8 +127,8 @@
 
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5.000', 'Solar should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '18.000', 'Grid should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '23.000', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-18.000', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-23.000', 'Home should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');

--- a/power-wheel-card/test/decimals.html
+++ b/power-wheel-card/test/decimals.html
@@ -29,6 +29,8 @@
         grid_energy_production_entity: "sensor.grid_energy_production",
         power_decimals: 2,
         energy_decimals: 1,
+        money_decimals: 3,
+        energy_price: 1.00,
       };
       hass = {
         states: {
@@ -88,6 +90,7 @@
       flush(() => {
         assert.equal(card.config.power_decimals, 2, 'Card parameter power_decimals should have value set');
         assert.equal(card.config.energy_decimals, 1, 'Card parameter energy_decimals should have value set');
+        assert.equal(card.config.money_decimals, 3, 'Card parameter money_decimals should have value set');
         done();
       });
     });
@@ -111,6 +114,20 @@
         assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5.0', 'Solar should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '18.0', 'Grid should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '23.0', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+        done();
+      });
+    });
+
+    test('displays values in money view', (done) => {
+      setCardView('money');
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5.000', 'Solar should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '18.000', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '23.000', 'Home should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');

--- a/power-wheel-card/test/energy_capable.html
+++ b/power-wheel-card/test/energy_capable.html
@@ -229,6 +229,30 @@
       });
     });
 
+    test('can click on unit to toggle from power view to energy view', (done) => {
+      setCardView('power');
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'W', 'Card should be in power view');
+        card.shadowRoot.querySelector('#toggle-button').click();
+        flush(() => {
+          assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'kWh', 'Card should be in energy view');
+          done();
+        });
+      })
+    });
+
+    test('can click on unit to toggle from energy view to power view', (done) => {
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'kWh', 'Card should be in energy view');
+        card.shadowRoot.querySelector('#toggle-button').click();
+        flush(() => {
+          assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'W', 'Card should be in power view');
+          done();
+        });
+      })
+    });
+
   });
 </script>
 </body>

--- a/power-wheel-card/test/energy_capable.html
+++ b/power-wheel-card/test/energy_capable.html
@@ -108,10 +108,10 @@
 
     test('has set card property values after setConfig', (done) => {
       flush(() => {
-        assert.isTrue(card.energy_capable, 'Card property energy_capable should be set');
-        assert.isFalse(card.money_capable, 'Card property money_capable should be default false');
         assert.deepEqual(card.sensors, [ "sensor.solar_power", "sensor.grid_power_consumption", "sensor.grid_power_production", "sensor.solar_energy", "sensor.grid_energy_consumption", "sensor.grid_energy_production" ], 'Card property sensors should be set');
         assert.equal(card.view, 'energy', 'Card property view should be set');
+        assert.isTrue(card.views.energy.capable, 'Card property views should have value set for energy capable');
+        assert.isFalse(card.views.money.capable, 'Card property views should have default value for money capable');
         done();
       });
     });

--- a/power-wheel-card/test/energy_capable.html
+++ b/power-wheel-card/test/energy_capable.html
@@ -235,6 +235,7 @@
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'W', 'Card should be in power view');
         card.shadowRoot.querySelector('#unit').click();
+
         flush(() => {
           assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'kWh', 'Card should be in energy view');
           done();
@@ -246,8 +247,22 @@
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'kWh', 'Card should be in energy view');
         card.shadowRoot.querySelector('#unit').click();
+
         flush(() => {
           assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'W', 'Card should be in power view');
+          done();
+        });
+      })
+    });
+
+    test('can switch on auto toggling with toggle button', (done) => {
+      flush(() => {
+        assert.isFalse(card.autoToggleView, 'Auto toggle should be switched off');
+        card.shadowRoot.querySelector('#toggle-button').click();
+
+        flush(() => {
+          // Auto toggle behavior itself is tested in auto_toggle.html
+          assert.isTrue(card.autoToggleView, 'Auto toggle should be switched on');
           done();
         });
       })

--- a/power-wheel-card/test/energy_capable.html
+++ b/power-wheel-card/test/energy_capable.html
@@ -234,7 +234,7 @@
 
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'W', 'Card should be in power view');
-        card.shadowRoot.querySelector('#toggle-button').click();
+        card.shadowRoot.querySelector('#unit').click();
         flush(() => {
           assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'kWh', 'Card should be in energy view');
           done();
@@ -245,7 +245,7 @@
     test('can click on unit to toggle from energy view to power view', (done) => {
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'kWh', 'Card should be in energy view');
-        card.shadowRoot.querySelector('#toggle-button').click();
+        card.shadowRoot.querySelector('#unit').click();
         flush(() => {
           assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'W', 'Card should be in power view');
           done();

--- a/power-wheel-card/test/energy_capable.html
+++ b/power-wheel-card/test/energy_capable.html
@@ -31,6 +31,7 @@
         grid_energy_consumption_entity: "sensor.grid_energy_consumption",
         grid_energy_production_entity: "sensor.grid_energy_production",
         initial_view: "energy",
+        color_icons: false,
       };
       hass = {
         states: {
@@ -152,8 +153,8 @@
     test('displays values when having consumed from the grid only', (done) => {
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5.000', 'Solar should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '18.000', 'Grid should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '23.000', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-18.000', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-23.000', 'Home should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
@@ -178,8 +179,8 @@
 
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5.000', 'Solar should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-0.500', 'Grid should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '4.500', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '0.500', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-4.500', 'Home should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '0.500', 'Solar2Grid arrow should have a correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '4.500', 'Solar2Home arrow should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
@@ -206,8 +207,8 @@
 
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5.000', 'Solar should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '0.500', 'Grid should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '5.500', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-0.500', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-5.500', 'Home should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '0.500', 'Solar2Grid arrow should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '4.500', 'Solar2Home arrow should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '1.000', 'Grid2Home arrow should have correct value');

--- a/power-wheel-card/test/energy_capable.html
+++ b/power-wheel-card/test/energy_capable.html
@@ -195,6 +195,9 @@
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('producing'), 'Solar icon should be producing');
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('producing'), 'Grid icon should be producing');
         assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('active'), 'Solar2Grid arrow icon should be active');
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('active'), 'Solar2Home arrow icon should be active');
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('inactive'), 'Grid2Home arrow icon should be inactive');
@@ -223,6 +226,9 @@
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('producing'), 'Solar icon should be producing');
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('consuming'), 'Grid icon should be consuming');
         assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('active'), 'Solar2Grid arrow icon should be active');
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('active'), 'Solar2Home arrow icon should be active');
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('active'), 'Grid2Home arrow icon should be active');

--- a/power-wheel-card/test/energy_one_grid_sensor.html
+++ b/power-wheel-card/test/energy_one_grid_sensor.html
@@ -1,0 +1,202 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../bower_components/webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="../../bower_components/web-component-tester/browser.js"></script>
+  <script type="module" src="../../test/home-assistant-main-mock.js"></script>
+  <script type="module" src="../power-wheel-card.js"></script>
+</head>
+<body>
+<test-fixture id="simple">
+  <template>
+    <power-wheel-card></power-wheel-card>
+  </template>
+</test-fixture>
+<script>
+  suite('<power-wheel-card> with energy view capable config for one grid sensor', () => {
+    let card, hass, config;
+
+    /** Tests are based on basic_config. **/
+    /** Tests are extended in money_capable. **/
+
+    setup(() => {
+      card = fixture('simple');
+      config = {
+        type: "custom:power-wheel-card",
+        solar_power_entity: "sensor.solar_power",
+        grid_power_consumption_entity: "sensor.grid_power_consumption",
+        grid_power_production_entity: "sensor.grid_power_production",
+        solar_energy_entity: "sensor.solar_energy",
+        grid_energy_entity: "sensor.grid_energy",
+        initial_view: "energy",
+        color_icons: false,
+      };
+      hass = {
+        states: {
+          "sensor.solar_power" : {
+            attributes: {
+              unit_of_measurement: "W",
+            },
+            entity_id: "sensor.solar_power",
+            state: "500.1",
+          },
+          "sensor.grid_power_consumption" : {
+            attributes: {
+              unit_of_measurement: "W",
+            },
+            entity_id: "sensor.grid_power_consumption",
+            state: "1799.9",
+          },
+          "sensor.grid_power_production" : {
+            attributes: {
+              unit_of_measurement: "W",
+            },
+            entity_id: "sensor.grid_power_production",
+            state: "0",
+          },
+          "sensor.solar_energy" : {
+            attributes: {
+              unit_of_measurement: "kWh",
+            },
+            entity_id: "sensor.solar_energy",
+            state: "5",
+          },
+          "sensor.grid_energy" : {
+            attributes: {
+              unit_of_measurement: "kWh",
+            },
+            entity_id: "sensor.grid_energy",
+            state: "-18",
+          },
+        },
+      };
+      card.setAttribute('hass', JSON.stringify(hass));
+      card.setConfig(config);
+    });
+
+    const setCardProducedToGridOnly = () => {
+      hass.states['sensor.grid_energy'].state = "0.5";
+      card.setAttribute('hass', JSON.stringify(hass));
+    };
+
+    const setCardConsumedAndProducedToGrid = () => {
+      hass.states['sensor.grid_energy'].state = "-0.5";
+      card.setAttribute('hass', JSON.stringify(hass));
+    };
+
+    test('has set card property values after setConfig', (done) => {
+      flush(() => {
+        assert.isFalse(card.views.power.oneGridSensor, 'Card property views should have value set for power oneGridSensor');
+        assert.isTrue(card.views.power.twoGridSensors, 'Card property views should have value set for power twoGridSensors');
+        assert.isTrue(card.views.energy.oneGridSensor, 'Card property views should have value set for energy oneGridSensor');
+        assert.isFalse(card.views.energy.twoGridSensors, 'Card property views should have value set for energy twoGridSensors');
+        done();
+      });
+    });
+
+    test('has no warnings or errors', (done) => {
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelectorAll('.message').length, 0, 'Number of messages should be zero');
+        done();
+      });
+    });
+
+    test('displays values', (done) => {
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#title').innerText, "Power wheel");
+        assert.equal(card.shadowRoot.querySelector('#unit').innerText, "kWh", 'Unit should be set to energy');
+        done();
+      });
+    });
+
+    test('displays values when having consumed from the grid only', (done) => {
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5.000', 'Solar should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-18.000', 'Grid should have correct value');
+        // assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-23.000', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+        done();
+      });
+    });
+
+    test('has ui elements when having consumed from the grid only', (done) => {
+      flush(() => {
+        assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('producing'), 'Solar icon should be producing');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('consuming'), 'Grid icon should be consuming');
+        // assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('inactive'), 'Solar2Grid arrow icon should be inactive');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('inactive'), 'Solar2Home arrow icon should be inactive');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('inactive'), 'Grid2Home arrow icon should be inactive');
+        done();
+      });
+    });
+
+    test('displays values when having produced to the grid only', (done) => {
+      setCardProducedToGridOnly();
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5.000', 'Solar should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '0.500', 'Grid should have correct value');
+        // assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-4.500', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+        done();
+      });
+    });
+
+    test('has ui elements when having produced to the grid only', (done) => {
+      setCardProducedToGridOnly();
+
+      flush(() => {
+        assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('producing'), 'Solar icon should be producing');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('producing'), 'Grid icon should be producing');
+        // assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('inactive'), 'Solar2Grid arrow icon should be inactive');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('inactive'), 'Solar2Home arrow icon should be inactive');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('inactive'), 'Grid2Home arrow icon should be inactive');
+        done();
+      });
+    });
+
+    test('displays values when having consumed from and produced to the grid', (done) => {
+      setCardConsumedAndProducedToGrid();
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5.000', 'Solar should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-0.500', 'Grid should have correct value');
+        // assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-5.500', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+        done();
+      });
+    });
+
+    test('has ui elements when having consumed from and produced to the grid', (done) => {
+      setCardConsumedAndProducedToGrid();
+
+      flush(() => {
+        assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('producing'), 'Solar icon should be producing');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('consuming'), 'Grid icon should be consuming');
+        // assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('inactive'), 'Solar2Grid arrow icon should be inactive');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('inactive'), 'Solar2Home arrow icon should be inactive');
+        assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('inactive'), 'Grid2Home arrow icon should be inactive');
+        done();
+      });
+    });
+
+  });
+</script>
+</body>
+</html>

--- a/power-wheel-card/test/energy_one_grid_sensor_switched_polarity.html
+++ b/power-wheel-card/test/energy_one_grid_sensor_switched_polarity.html
@@ -14,12 +14,12 @@
   </template>
 </test-fixture>
 <script>
-  suite('<power-wheel-card> with energy view capable config for one grid sensor', () => {
+  suite('<power-wheel-card> with energy view capable config for one grid sensor with switched polarity', () => {
     let card, hass, config;
 
     /** Tests are based on basic_config. **/
     /** Tests are extended in money_capable. **/
-    /** Tests are also used in energy_one_grid_sensor_switched_polarity.html **/
+    /** Tests are also used in energy_one_grid_sensor.html **/
 
     setup(() => {
       card = fixture('simple');
@@ -31,7 +31,7 @@
         solar_energy_entity: "sensor.solar_energy",
         grid_energy_entity: "sensor.grid_energy",
         home_energy_entity: "sensor.home_energy",
-        production_is_positive: true,
+        production_is_positive: false,
         initial_view: "energy",
         color_icons: false,
       };
@@ -70,14 +70,14 @@
               unit_of_measurement: "kWh",
             },
             entity_id: "sensor.grid_energy",
-            state: "-18",
+            state: "18",
           },
           "sensor.home_energy" : {
             attributes: {
               unit_of_measurement: "kWh",
             },
             entity_id: "sensor.home_energy",
-            state: "-23",
+            state: "23",
           },
         },
       };
@@ -86,14 +86,14 @@
     });
 
     const setCardProducedToGridOnly = () => {
-      hass.states['sensor.grid_energy'].state = "0.5";
-      hass.states['sensor.home_energy'].state = "-4.5";
+      hass.states['sensor.grid_energy'].state = "-0.5";
+      hass.states['sensor.home_energy'].state = "4.5";
       card.setAttribute('hass', JSON.stringify(hass));
     };
 
     const setCardConsumedAndProducedToGrid = () => {
-      hass.states['sensor.grid_energy'].state = "-0.5";
-      hass.states['sensor.home_energy'].state = "-5.5";
+      hass.states['sensor.grid_energy'].state = "0.5";
+      hass.states['sensor.home_energy'].state = "5.5";
       card.setAttribute('hass', JSON.stringify(hass));
     };
 

--- a/power-wheel-card/test/icon_colors.html
+++ b/power-wheel-card/test/icon_colors.html
@@ -26,7 +26,6 @@
         solar_power_entity: "sensor.solar_power",
         grid_power_consumption_entity: "sensor.grid_power_consumption",
         grid_power_production_entity: "sensor.grid_power_production",
-        color_icons: true,
         consuming_color: "red",
         producing_color: "green",
       };

--- a/power-wheel-card/test/icons_by_config.html
+++ b/power-wheel-card/test/icons_by_config.html
@@ -28,6 +28,11 @@
         grid_power_production_entity: "sensor.grid_power_production",
         grid_power_entity: "sensor.grid_power",
         home_power_entity: "sensor.home_power",
+        solar_energy_entity: "sensor.solar_energy",
+        grid_energy_consumption_entity: "sensor.grid_energy_consumption",
+        grid_energy_production_entity: "sensor.grid_energy_production",
+        grid_energy_entity: "sensor.grid_energy",
+        home_energy_entity: "sensor.home_energy",
         solar_icon: "mdi:solar-power",
         grid_icon: "mdi:flash",
         home_icon: "mdi:home-circle",
@@ -72,13 +77,66 @@
             entity_id: "sensor.grid_power",
             state: "999",
           },
+          "sensor.solar_energy" : {
+            attributes: {
+              unit_of_measurement: "kWh",
+              icon: "mdi:white-balance-sunny",
+            },
+            entity_id: "sensor.solar_energy",
+            state: "5",
+          },
+          "sensor.grid_energy_consumption" : {
+            attributes: {
+              unit_of_measurement: "kWh",
+            },
+            entity_id: "sensor.grid_energy_consumption",
+            state: "18",
+          },
+          "sensor.grid_energy_production" : {
+            attributes: {
+              unit_of_measurement: "kWh",
+            },
+            entity_id: "sensor.grid_energy_production",
+            state: "0",
+          },
+          "sensor.grid_energy" : {
+            attributes: {
+              unit_of_measurement: "W",
+              icon: "mdi:flash-circle",
+            },
+            entity_id: "sensor.grid_energy",
+            state: "999",
+          },
+          "sensor.home_energy" : {
+            attributes: {
+              unit_of_measurement: "W",
+              icon: "mdi:home-assistant",
+            },
+            entity_id: "sensor.grid_energy",
+            state: "999",
+          },
         },
       };
       card.setAttribute('hass', JSON.stringify(hass));
       card.setConfig(config);
     });
 
-    test('prefers configured icons above customized icons', (done) => {
+    const setCardView = (view) => {
+      card.setAttribute('view', view);
+    };
+
+    test('prefers configured icons above customized icons in power view', (done) => {
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#icon-solar').getAttribute('icon'), 'mdi:solar-power', 'Solar icon should be configured icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-grid').getAttribute('icon'), 'mdi:flash', 'Grid icon should be configured icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-home').getAttribute('icon'), 'mdi:home-circle', 'Home icon should be configured icon');
+        done();
+      });
+    });
+
+    test('prefers configured icons above customized icons in energy view', (done) => {
+      setCardView('energy');
+
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#icon-solar').getAttribute('icon'), 'mdi:solar-power', 'Solar icon should be configured icon');
         assert.equal(card.shadowRoot.querySelector('#icon-grid').getAttribute('icon'), 'mdi:flash', 'Grid icon should be configured icon');

--- a/power-wheel-card/test/icons_by_customize.html
+++ b/power-wheel-card/test/icons_by_customize.html
@@ -33,6 +33,7 @@
         grid_energy_production_entity: "sensor.grid_energy_production",
         grid_energy_entity: "sensor.grid_energy",
         home_energy_entity: "sensor.home_energy",
+        color_icons: false,
       };
       hass = {
         states: {
@@ -134,8 +135,8 @@
     test('in power view doesn\'t let the extra sensors interfere values when consuming from the grid', (done) => {
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '500', 'Solar should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '1800', 'Grid should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '2300', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-1800', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-2300', 'Home should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
@@ -159,8 +160,8 @@
 
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5.000', 'Solar should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '18.000', 'Grid should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '23.000', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-18.000', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-23.000', 'Home should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');

--- a/power-wheel-card/test/icons_by_customize.html
+++ b/power-wheel-card/test/icons_by_customize.html
@@ -28,6 +28,11 @@
         grid_power_production_entity: "sensor.grid_power_production",
         grid_power_entity: "sensor.grid_power",
         home_power_entity: "sensor.home_power",
+        solar_energy_entity: "sensor.solar_energy",
+        grid_energy_consumption_entity: "sensor.grid_energy_consumption",
+        grid_energy_production_entity: "sensor.grid_energy_production",
+        grid_energy_entity: "sensor.grid_energy",
+        home_energy_entity: "sensor.home_energy",
       };
       hass = {
         states: {
@@ -69,13 +74,55 @@
             entity_id: "sensor.grid_power",
             state: "999",
           },
+          "sensor.solar_energy" : {
+            attributes: {
+              unit_of_measurement: "kWh",
+              icon: "mdi:white-balance-sunny",
+            },
+            entity_id: "sensor.solar_energy",
+            state: "5",
+          },
+          "sensor.grid_energy_consumption" : {
+            attributes: {
+              unit_of_measurement: "kWh",
+            },
+            entity_id: "sensor.grid_energy_consumption",
+            state: "18",
+          },
+          "sensor.grid_energy_production" : {
+            attributes: {
+              unit_of_measurement: "kWh",
+            },
+            entity_id: "sensor.grid_energy_production",
+            state: "0",
+          },
+          "sensor.grid_energy" : {
+            attributes: {
+              unit_of_measurement: "W",
+              icon: "mdi:flash-circle",
+            },
+            entity_id: "sensor.grid_energy",
+            state: "999",
+          },
+          "sensor.home_energy" : {
+            attributes: {
+              unit_of_measurement: "W",
+              icon: "mdi:home-assistant",
+            },
+            entity_id: "sensor.grid_energy",
+            state: "999",
+          },
         },
       };
       card.setAttribute('hass', JSON.stringify(hass));
       card.setConfig(config);
     });
 
-    test('has customized icons', (done) => {
+    const setCardView = (view) => {
+      card.setAttribute('view', view);
+    };
+
+    test('has customized icons in power view', (done) => {
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#icon-solar').getAttribute('icon'), 'mdi:white-balance-sunny', 'Solar icon should be customized icon');
         assert.equal(card.shadowRoot.querySelector('#icon-grid').getAttribute('icon'), 'mdi:flash-circle', 'Grid icon should be customized icon');
@@ -84,11 +131,36 @@
       });
     });
 
-    test('doesn\'t let the extra sensors interfere values when consuming from the grid', (done) => {
+    test('in power view doesn\'t let the extra sensors interfere values when consuming from the grid', (done) => {
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '500', 'Solar should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '1800', 'Grid should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '2300', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+        done();
+      });
+    });
+
+    test('has customized icons in energy view', (done) => {
+      setCardView('energy');
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#icon-solar').getAttribute('icon'), 'mdi:white-balance-sunny', 'Solar icon should be customized icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-grid').getAttribute('icon'), 'mdi:flash-circle', 'Grid icon should be customized icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-home').getAttribute('icon'), 'mdi:home-assistant', 'Home icon should be customized icon');
+        done();
+      });
+    });
+
+    test('in energy view doesn\'t let the extra sensors interfere values when consuming from the grid', (done) => {
+      setCardView('energy');
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5.000', 'Solar should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '18.000', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '23.000', 'Home should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');

--- a/power-wheel-card/test/money_capable.html
+++ b/power-wheel-card/test/money_capable.html
@@ -32,6 +32,7 @@
         energy_price: 0.20,
         money_unit: '$',
         initial_view: "money",
+        color_icons: false,
       };
       hass = {
         states: {
@@ -165,8 +166,8 @@
     test('displays values when having consumed from the grid only', (done) => {
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '1.00', 'Solar should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '3.60', 'Grid should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '4.60', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-3.60', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-4.60', 'Home should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
@@ -191,8 +192,8 @@
 
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '1.00', 'Solar should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-0.10', 'Grid should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '0.90', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '0.10', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-0.90', 'Home should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '0.10', 'Solar2Grid arrow should have a correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '0.90', 'Solar2Home arrow should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
@@ -219,8 +220,8 @@
 
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '1.00', 'Solar should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '0.10', 'Grid should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '1.10', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-0.10', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-1.10', 'Home should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '0.10', 'Solar2Grid arrow should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '0.90', 'Solar2Home arrow should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '0.20', 'Grid2Home arrow should have correct value');

--- a/power-wheel-card/test/money_capable.html
+++ b/power-wheel-card/test/money_capable.html
@@ -242,6 +242,43 @@
       });
     });
 
+    test('can click on unit to toggle from power view to energy view', (done) => {
+      setCardView('power');
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'W', 'Card should be in power view');
+        card.shadowRoot.querySelector('#toggle-button').click();
+        flush(() => {
+          assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'kWh', 'Card should be in energy view');
+          done();
+        });
+      })
+    });
+
+    test('can click on unit to toggle from energy view to money view', (done) => {
+      setCardView('energy');
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'kWh', 'Card should be in energy view');
+        card.shadowRoot.querySelector('#toggle-button').click();
+        flush(() => {
+          assert.equal(card.shadowRoot.querySelector('#unit').innerText, '$', 'Card should be in money view');
+          done();
+        });
+      })
+    });
+
+    test('can click on unit to toggle from money view to power view', (done) => {
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#unit').innerText, '$', 'Card should be in money view');
+        card.shadowRoot.querySelector('#toggle-button').click();
+        flush(() => {
+          assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'W', 'Card should be in power view');
+          done();
+        });
+      })
+    });
+
   });
 </script>
 </body>

--- a/power-wheel-card/test/money_capable.html
+++ b/power-wheel-card/test/money_capable.html
@@ -110,10 +110,10 @@
 
     test('has set card property values after setConfig', (done) => {
       flush(() => {
-        assert.isTrue(card.energy_capable, 'Card property energy_capable should be set');
-        assert.isTrue(card.money_capable, 'Card property money_capable should be set');
         assert.deepEqual(card.sensors, [ "sensor.solar_power", "sensor.grid_power_consumption", "sensor.grid_power_production", "sensor.solar_energy", "sensor.grid_energy_consumption", "sensor.grid_energy_production" ], 'Card property sensors should be set');
         assert.equal(card.view, 'money', 'Card property view should be set');
+        assert.isTrue(card.views.energy.capable, 'Card property views should have value set for energy capable');
+        assert.isTrue(card.views.money.capable, 'Card property views should have value set for money capable');
         done();
       });
     });

--- a/power-wheel-card/test/money_capable.html
+++ b/power-wheel-card/test/money_capable.html
@@ -180,6 +180,9 @@
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('producing'), 'Solar icon should be producing');
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('consuming'), 'Grid icon should be consuming');
         assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('inactive'), 'Solar2Grid arrow icon should be inactive');
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('active'), 'Solar2Home arrow icon should be active');
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('active'), 'Grid2Home arrow icon should be active');
@@ -208,6 +211,9 @@
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('producing'), 'Solar icon should be producing');
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('producing'), 'Grid icon should be producing');
         assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('active'), 'Solar2Grid arrow icon should be active');
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('active'), 'Solar2Home arrow icon should be active');
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('inactive'), 'Grid2Home arrow icon should be inactive');
@@ -236,6 +242,9 @@
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('producing'), 'Solar icon should be producing');
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('consuming'), 'Grid icon should be consuming');
         assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
+        assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('active'), 'Solar2Grid arrow icon should be active');
         assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('active'), 'Solar2Home arrow icon should be active');
         assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('active'), 'Grid2Home arrow icon should be active');

--- a/power-wheel-card/test/money_capable.html
+++ b/power-wheel-card/test/money_capable.html
@@ -247,7 +247,7 @@
 
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'W', 'Card should be in power view');
-        card.shadowRoot.querySelector('#toggle-button').click();
+        card.shadowRoot.querySelector('#unit').click();
         flush(() => {
           assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'kWh', 'Card should be in energy view');
           done();
@@ -260,7 +260,7 @@
 
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'kWh', 'Card should be in energy view');
-        card.shadowRoot.querySelector('#toggle-button').click();
+        card.shadowRoot.querySelector('#unit').click();
         flush(() => {
           assert.equal(card.shadowRoot.querySelector('#unit').innerText, '$', 'Card should be in money view');
           done();
@@ -271,7 +271,7 @@
     test('can click on unit to toggle from money view to power view', (done) => {
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#unit').innerText, '$', 'Card should be in money view');
-        card.shadowRoot.querySelector('#toggle-button').click();
+        card.shadowRoot.querySelector('#unit').click();
         flush(() => {
           assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'W', 'Card should be in power view');
           done();

--- a/power-wheel-card/test/money_capable.html
+++ b/power-wheel-card/test/money_capable.html
@@ -14,11 +14,10 @@
   </template>
 </test-fixture>
 <script>
-  suite('<power-wheel-card> with energy view capable config', () => {
+  suite('<power-wheel-card> with money view capable config', () => {
     let card, hass, config;
 
-    /** Tests are based on basic_config. **/
-    /** Tests are extended in money_capable. **/
+    /** Tests are based on energy_capable. **/
 
     setup(() => {
       card = fixture('simple');
@@ -30,7 +29,9 @@
         solar_energy_entity: "sensor.solar_energy",
         grid_energy_consumption_entity: "sensor.grid_energy_consumption",
         grid_energy_production_entity: "sensor.grid_energy_production",
-        initial_view: "energy",
+        energy_price: 0.20,
+        money_unit: '$',
+        initial_view: "money",
       };
       hass = {
         states: {
@@ -100,7 +101,8 @@
 
     test('has config values', (done) => {
       flush(() => {
-        assert.equal(card.config.initial_view, 'energy', 'Card parameter initial_view should be set');
+        assert.equal(card.config.money_unit, '$', 'Card parameter money_unit should be set');
+        assert.equal(card.config.initial_view, 'money', 'Card parameter initial_view should be set');
         done();
       });
     });
@@ -108,9 +110,9 @@
     test('has set card property values after setConfig', (done) => {
       flush(() => {
         assert.isTrue(card.energy_capable, 'Card property energy_capable should be set');
-        assert.isFalse(card.money_capable, 'Card property money_capable should be default false');
+        assert.isTrue(card.money_capable, 'Card property money_capable should be set');
         assert.deepEqual(card.sensors, [ "sensor.solar_power", "sensor.grid_power_consumption", "sensor.grid_power_production", "sensor.solar_energy", "sensor.grid_energy_consumption", "sensor.grid_energy_production" ], 'Card property sensors should be set');
-        assert.equal(card.view, 'energy', 'Card property view should be set');
+        assert.equal(card.view, 'money', 'Card property view should be set');
         done();
       });
     });
@@ -125,7 +127,7 @@
     test('displays values', (done) => {
       flush(() => {
         assert.equal(card.shadowRoot.querySelector('#title').innerText, "Power wheel");
-        assert.equal(card.shadowRoot.querySelector('#unit').innerText, "kWh", 'Unit should be set to energy');
+        assert.equal(card.shadowRoot.querySelector('#unit').innerText, "$", 'Unit should be set to money');
         done();
       });
     });
@@ -142,6 +144,17 @@
     });
 
     test('has ui elements in energy view', (done) => {
+      setCardView('energy');
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#unit').innerText, "kWh", 'Card should be in energy view');
+        assert.equal(card.shadowRoot.querySelectorAll('#toggle-button').length, 1, 'Toggle button should be there');
+        assert.isTrue(card.shadowRoot.querySelector('#unit').classList.contains('toggle'), 'Unit should be toggleable');
+        done();
+      });
+    });
+
+    test('has ui elements in money view', (done) => {
       flush(() => {
         assert.equal(card.shadowRoot.querySelectorAll('#toggle-button').length, 1, 'Toggle button should be there');
         assert.isTrue(card.shadowRoot.querySelector('#unit').classList.contains('toggle'), 'Unit should be toggleable');
@@ -151,9 +164,9 @@
 
     test('displays values when having consumed from the grid only', (done) => {
       flush(() => {
-        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5.000', 'Solar should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '18.000', 'Grid should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '23.000', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '1.00', 'Solar should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '3.60', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '4.60', 'Home should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
         assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
@@ -177,11 +190,11 @@
       setCardProducedToGridOnly();
 
       flush(() => {
-        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5.000', 'Solar should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-0.500', 'Grid should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '4.500', 'Home should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '0.500', 'Solar2Grid arrow should have a correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '4.500', 'Solar2Home arrow should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '1.00', 'Solar should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-0.10', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '0.90', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '0.10', 'Solar2Grid arrow should have a correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '0.90', 'Solar2Home arrow should have correct value');
         assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
         done();
       });
@@ -205,12 +218,12 @@
       setCardConsumedAndProducedToGrid();
 
       flush(() => {
-        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5.000', 'Solar should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '0.500', 'Grid should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '5.500', 'Home should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '0.500', 'Solar2Grid arrow should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '4.500', 'Solar2Home arrow should have correct value');
-        assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '1.000', 'Grid2Home arrow should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '1.00', 'Solar should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '0.10', 'Grid should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '1.10', 'Home should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '0.10', 'Solar2Grid arrow should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '0.90', 'Solar2Home arrow should have correct value');
+        assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '0.20', 'Grid2Home arrow should have correct value');
         done();
       });
     });

--- a/power-wheel-card/test/titles.html
+++ b/power-wheel-card/test/titles.html
@@ -98,7 +98,9 @@
 
     test('has set card property values after setConfig', (done) => {
       flush(() => {
-        assert.deepEqual(card.titles, { power: "Power view", energy: "Energy view", money: "Money view" }, 'Card property titles should be set');
+        assert.equal(card.views.power.title, 'Power view', 'Card property views should have value set for power view title');
+        assert.equal(card.views.energy.title, 'Energy view', 'Card property views should have value set for energy view title');
+        assert.equal(card.views.money.title, 'Money view', 'Card property views should have value set for money view title');
         done();
       });
     });

--- a/power-wheel-card/test/titles.html
+++ b/power-wheel-card/test/titles.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../bower_components/webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="../../bower_components/web-component-tester/browser.js"></script>
+  <script type="module" src="../../test/home-assistant-main-mock.js"></script>
+  <script type="module" src="../power-wheel-card.js"></script>
+</head>
+<body>
+<test-fixture id="simple">
+  <template>
+    <power-wheel-card></power-wheel-card>
+  </template>
+</test-fixture>
+<script>
+  suite('<power-wheel-card> with a title per view', () => {
+    let card, hass, config;
+
+    setup(() => {
+      card = fixture('simple');
+      config = {
+        type: "custom:power-wheel-card",
+        title: "Not used",
+        title_power: "Power view",
+        title_energy: "Energy view",
+        title_money: "Money view",
+        solar_power_entity: "sensor.solar_power",
+        grid_power_consumption_entity: "sensor.grid_power_consumption",
+        grid_power_production_entity: "sensor.grid_power_production",
+        solar_energy_entity: "sensor.solar_energy",
+        grid_energy_consumption_entity: "sensor.grid_energy_consumption",
+        grid_energy_production_entity: "sensor.grid_energy_production",
+        energy_price: 0.20,
+      };
+      hass = {
+        states: {
+          "sensor.solar_power" : {
+            attributes: {
+              unit_of_measurement: "W",
+            },
+            entity_id: "sensor.solar_power",
+            state: "500.1",
+          },
+          "sensor.grid_power_consumption" : {
+            attributes: {
+              unit_of_measurement: "W",
+            },
+            entity_id: "sensor.grid_power_consumption",
+            state: "1799.9",
+          },
+          "sensor.grid_power_production" : {
+            attributes: {
+              unit_of_measurement: "W",
+            },
+            entity_id: "sensor.grid_power_production",
+            state: "0",
+          },
+          "sensor.solar_energy" : {
+            attributes: {
+              unit_of_measurement: "kWh",
+            },
+            entity_id: "sensor.solar_energy",
+            state: "5",
+          },
+          "sensor.grid_energy_consumption" : {
+            attributes: {
+              unit_of_measurement: "kWh",
+            },
+            entity_id: "sensor.grid_energy_consumption",
+            state: "18",
+          },
+          "sensor.grid_energy_production" : {
+            attributes: {
+              unit_of_measurement: "kWh",
+            },
+            entity_id: "sensor.grid_energy_production",
+            state: "0",
+          },
+        },
+      };
+      card.setAttribute('hass', JSON.stringify(hass));
+      card.setConfig(config);
+    });
+
+    const setCardView = (view) => {
+      card.setAttribute('view', view);
+    };
+
+    test('has config values', (done) => {
+      flush(() => {
+        assert.equal(card.config.title_power, 'Power view', 'Card parameter title_power should be set');
+        assert.equal(card.config.title_energy, 'Energy view', 'Card parameter title_energy should be set');
+        assert.equal(card.config.title_money, 'Money view', 'Card parameter title_money should be set');
+        done();
+      });
+    });
+
+    test('has set card property values after setConfig', (done) => {
+      flush(() => {
+        assert.deepEqual(card.titles, { power: "Power view", energy: "Energy view", money: "Money view" }, 'Card property titles should be set');
+        done();
+      });
+    });
+
+    test('has no warnings or errors', (done) => {
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelectorAll('.message').length, 0, 'Number of messages should be zero');
+        done();
+      });
+    });
+
+    test('displays values in power view', (done) => {
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#title').innerText, "Power view");
+        done();
+      });
+    });
+
+    test('displays values in energy view', (done) => {
+      setCardView('energy');
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#title').innerText, "Energy view");
+        done();
+      });
+    });
+
+    test('displays values in money view', (done) => {
+      setCardView('money');
+
+      flush(() => {
+        assert.equal(card.shadowRoot.querySelector('#title').innerText, "Money view");
+        done();
+      });
+    });
+
+  });
+</script>
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -13,6 +13,7 @@
     '../power-wheel-card/test/icon_colors.html',
     '../power-wheel-card/test/icons_by_customize.html',
     '../power-wheel-card/test/icons_by_config.html',
+    '../power-wheel-card/test/titles.html',
     '../power-wheel-card/test/decimals.html',
     '../power-wheel-card/test/energy_capable.html',
     '../power-wheel-card/test/money_capable.html',

--- a/test/index.html
+++ b/test/index.html
@@ -19,6 +19,7 @@
     '../power-wheel-card/test/decimals.html',
     '../power-wheel-card/test/energy_capable.html',
     '../power-wheel-card/test/energy_one_grid_sensor.html',
+    '../power-wheel-card/test/energy_one_grid_sensor_switched_polarity.html',
     '../power-wheel-card/test/money_capable.html',
     '../power-wheel-card/test/auto_toggle.html',
     '../power-wheel-card/test/debug_mode.html',

--- a/test/index.html
+++ b/test/index.html
@@ -17,6 +17,7 @@
     '../power-wheel-card/test/decimals.html',
     '../power-wheel-card/test/energy_capable.html',
     '../power-wheel-card/test/money_capable.html',
+    '../power-wheel-card/test/auto_toggle.html',
   ]);
 </script>
 </body>

--- a/test/index.html
+++ b/test/index.html
@@ -15,6 +15,7 @@
     '../power-wheel-card/test/icons_by_config.html',
     '../power-wheel-card/test/decimals.html',
     '../power-wheel-card/test/energy_capable.html',
+    '../power-wheel-card/test/money_capable.html',
   ]);
 </script>
 </body>

--- a/test/index.html
+++ b/test/index.html
@@ -9,6 +9,7 @@
 <script>
   WCT.loadSuites([
     '../power-wheel-card/test/basic_config.html',
+    '../power-wheel-card/test/basic_one_grid_sensor.html',
     '../power-wheel-card/test/color_icons.html',
     '../power-wheel-card/test/icon_colors.html',
     '../power-wheel-card/test/icons_by_customize.html',

--- a/test/index.html
+++ b/test/index.html
@@ -10,6 +10,7 @@
   WCT.loadSuites([
     '../power-wheel-card/test/basic_config.html',
     '../power-wheel-card/test/basic_one_grid_sensor.html',
+    '../power-wheel-card/test/basic_one_grid_sensor_switched_polarity.html',
     '../power-wheel-card/test/color_icons.html',
     '../power-wheel-card/test/icon_colors.html',
     '../power-wheel-card/test/icons_by_customize.html',

--- a/test/index.html
+++ b/test/index.html
@@ -18,6 +18,7 @@
     '../power-wheel-card/test/energy_capable.html',
     '../power-wheel-card/test/money_capable.html',
     '../power-wheel-card/test/auto_toggle.html',
+    '../power-wheel-card/test/debug_mode.html',
   ]);
 </script>
 </body>

--- a/test/index.html
+++ b/test/index.html
@@ -18,6 +18,7 @@
     '../power-wheel-card/test/titles.html',
     '../power-wheel-card/test/decimals.html',
     '../power-wheel-card/test/energy_capable.html',
+    '../power-wheel-card/test/energy_one_grid_sensor.html',
     '../power-wheel-card/test/money_capable.html',
     '../power-wheel-card/test/auto_toggle.html',
     '../power-wheel-card/test/debug_mode.html',

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -3,6 +3,12 @@
   "plugins": {
     "local": {
       "browsers": ["chrome"]
+    },
+    "istanbub": {
+      "reporters": ["text-summary", "lcov"],
+      "include": [
+        "/power-wheel-card/*.js"
+      ]
     }
   }
 }


### PR DESCRIPTION
## 0.0.11
### New features
* Support for one (nett) grid power sensor.
Some setups don't have separate sensors for grid power consumption (from the grid) and grid power production (to the grid).
Previously you had to make an extra template sensor for this.
  * Use current card parameter `grid_power_entity` to supply your input for the card.
Default the polarity of this parameter has to be positive for producing (to the grid) and negative for consuming (from the grid). 
* Support for one (nett) grid energy sensor.
Some setups don't have separate sensors for grid energy consumption (from the grid) and grid energy production (to the grid).
Previously you were not able to use the *energy view*.
  * Use current card parameter `grid_energy_entity` to supply your input for the card.
  * Use current card parameter `home_energy_entity` to supply your input for the card. This extra parameter is needed because the consumed energy of your home can't be calculated if you only have one grid energy sensor.
  * Default the polarity of these parameters has to be positive for producing (to the grid) and negative for consuming (from the grid).
  * Nb. There still won't be active arrows in the *energy view* nor values near the arrows.
This is because you supply too less information to calculate these values.
Power-wheel-card can't do magic.
* Support for switching the polarity of `grid_power_entity`, `grid_energy_entity` and `home_energy_entity`.
Default the polarity of these parameters has to be positive for producing (to the grid) and negative for consuming (from the grid).
  * You can switch the polarity of all these 3 entities with the new card parameter `production_is_positive`.
  * Nb. The parameter is switching the polarity of exactly only the 3 mentioned input parameters. All other input parameters are not affected.
  * Nb. The parameter is switching the polarity of **input** values to be able to use them in calculations. Negative output values (i.e. displayed values) always represent consuming (from the grid).  
### Improvements
* Arrows will reverse when their value becomes negative.
(E.g. solar panel inverters start consuming when there is no sun and some users have a sensor that detects this.)
The values next to arrows always are positive now. 
* About coloring the *solar*, *grid* and *home* icons, polarity of their values ('+' when producing, '-' when consuming) and sign of their values ('+' or '-'):
  * When `color_icons` is set to `true` the Solar, Grid and Home values always are displayed as positive values,
because the color of the icon represents the plus or minus sign already. 
  * The polarity of the values for Grid and Home is switched for better consistency throughout the card.
The polarity of the colors stayed the same.
The changed polarity is visible only when `color_icons` is set to `false`, because negative values are displayed then only.
  * Card parameter `color_icons` is now default `true`.
If you don't want colored icons and see negative values, you have to set the parameter to `false` explicitly.
* Added user agent to the debug output.
* Automated testing before each commit.
* Added tests to get a good functional and code coverage. There are 627 tests now.
